### PR TITLE
CC-1330: Discard all logs from build exe step

### DIFF
--- a/internal/custom_executable/build.go
+++ b/internal/custom_executable/build.go
@@ -3,6 +3,7 @@ package custom_executable
 import (
 	_ "embed"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -25,7 +26,8 @@ func ReplaceAndBuild(content, outputPath, placeholder, randomString string) erro
 
 	// Run go build command
 	buildCmd := exec.Command("go", "build", "-o", outputPath, "tmp.go")
-	buildCmd.Stderr = os.Stderr
+	buildCmd.Stdout = io.Discard
+	buildCmd.Stderr = io.Discard
 	if err := buildCmd.Run(); err != nil {
 		return fmt.Errorf("CodeCrafters Internal Error: go build failed: %w", err)
 	}


### PR DESCRIPTION
This pull request includes changes to the `internal/custom_executable/build.go` file in the `custom_executable` package. The changes are primarily focused on improving the build process by adjusting the output of the build command and adding a new import.

The most significant changes are:

* [`internal/custom_executable/build.go`](diffhunk://#diff-1feeb6dd9657ef74d6c43569aa8541a663c8fbc373015dd49a5adf7676f7fa60R6): Added `io` to the import block to allow for output discarding.
* [`internal/custom_executable/build.go`](diffhunk://#diff-1feeb6dd9657ef74d6c43569aa8541a663c8fbc373015dd49a5adf7676f7fa60L28-R30): In the `ReplaceAndBuild` function, the `Stderr` and `Stdout` of `buildCmd` have been set to `io.Discard` to suppress the output of the build command.