### PR TITLE
CC-1349: Remove reliance on go executable in build environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ build:
 	go build -o dist/main.out ./cmd/tester
 
 test:
-	go test -count=1 -p 1 -v ./internal/...
+	TESTER_DIR=$(shell pwd) go test -count=1 -p 1 -v ./internal/...
 
 test_bash: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/bash \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
 		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
 		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Missing Command\"}, \
@@ -36,7 +36,7 @@ test_bash: build
 	dist/main.out
 
 test_dash: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/dash \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/dash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
 		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
 		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Missing Command\"}, \
@@ -54,7 +54,7 @@ test_dash: build
 	dist/main.out
 
 test_ryan: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/ryan_shell \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/ryan_shell \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
 		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
 		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Missing Command\"}, \
@@ -69,7 +69,7 @@ test_ryan: build
 test_all_success: test_bash test_dash
 
 test_failure: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/failure \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/failure \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
 		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
 		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Missing Command\"}, \
@@ -80,7 +80,7 @@ test_failure: build
 
 # Removes ALL zsh related config files across the system
 test_zsh_dangerously: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/zsh \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/zsh \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
 		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
 		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Missing Command\"}, \

--- a/internal/custom_executable/build.go
+++ b/internal/custom_executable/build.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -25,7 +26,11 @@ func ReplaceAndBuild(content, outputPath, placeholder, randomString string) erro
 	file.WriteString(content)
 
 	// Run go build command
-	buildCmd := exec.Command("go", "build", "-o", outputPath, "tmp.go")
+	goCmdFullPath := path.Join(os.Getenv("TESTER_DIR"), "go")
+	if goCmdFullPath == "" {
+		return fmt.Errorf("CodeCrafters Internal Error: Couldn't find tcc command")
+	}
+	buildCmd := exec.Command(goCmdFullPath, "build", "-o", outputPath, "tmp.go")
 	buildCmd.Stdout = io.Discard
 	buildCmd.Stderr = io.Discard
 	if err := buildCmd.Run(); err != nil {

--- a/internal/custom_executable/build.go
+++ b/internal/custom_executable/build.go
@@ -28,7 +28,7 @@ func ReplaceAndBuild(content, outputPath, placeholder, randomString string) erro
 	// Run go build command
 	goCmdFullPath := path.Join(os.Getenv("TESTER_DIR"), "go")
 	if goCmdFullPath == "" {
-		return fmt.Errorf("CodeCrafters Internal Error: Couldn't find tcc command")
+		return fmt.Errorf("CodeCrafters Internal Error: Couldn't find packaged go command")
 	}
 	buildCmd := exec.Command(goCmdFullPath, "build", "-o", outputPath, "tmp.go")
 	buildCmd.Stdout = io.Discard

--- a/main.goreleaser.yml
+++ b/main.goreleaser.yml
@@ -11,3 +11,5 @@ archives:
     format: tar.gz
     files:
       - test.sh
+      # Include the go binary in the archive, we use this for building custom_executables 
+      - go


### PR DESCRIPTION
This pull request includes updates to the build command and makefile, as well as the addition of a go executable. The build command has been updated to use the included go executable, and the makefile has been updated accordingly. Additionally, a go executable has been added to the repository. These changes aim to improve the build process and provide a more streamlined development experience.