### PR TITLE
Remove log and improve error message for missing packaged go command

### DIFF
--- a/internal/custom_executable/build.go
+++ b/internal/custom_executable/build.go
@@ -26,9 +26,10 @@ func ReplaceAndBuild(content, outputPath, placeholder, randomString string) erro
 	file.WriteString(content)
 
 	// Run go build command
+	// ToDo: Remove log
 	goCmdFullPath := path.Join(os.Getenv("TESTER_DIR"), "go")
-	if goCmdFullPath == "" {
-		return fmt.Errorf("CodeCrafters Internal Error: Couldn't find packaged go command")
+	if goCmdFullPath == "go" {
+		return fmt.Errorf("CodeCrafters Internal Error: Couldn't find packaged go command.\nTESTER_DIR: %s", os.Getenv("TESTER_DIR"))
 	}
 	buildCmd := exec.Command(goCmdFullPath, "build", "-o", outputPath, "tmp.go")
 	buildCmd.Stdout = io.Discard


### PR DESCRIPTION
This pull request includes a small but important change to the error handling in the `ReplaceAndBuild` function in `internal/custom_executable/build.go`. The change enhances the error message when the `go` command is not found.

* [`internal/custom_executable/build.go`](diffhunk://#diff-1feeb6dd9657ef74d6c43569aa8541a663c8fbc373015dd49a5adf7676f7fa60R29-R32): Modified the error message to include the `TESTER_DIR` environment variable when the `go` command is not found.