### PR TITLE
Refactor ShellExecutable and update error message

### DIFF
--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -142,18 +142,13 @@ func (b *ShellExecutable) WaitForTermination() (hasTerminated bool, exitCode int
 }
 
 func (b *ShellExecutable) ExitCode() int {
-	if b.cmd.ProcessState == nil {
-		// We are okay with waiting here,
-		// Since if the user's shell is still running, read would have timed out
-		// If it didn't time out, it means the program has exited, that's why we are here
-		exited, exitCode := b.WaitForTermination()
-		if !exited {
-			// fmt.Println("Process has not exited yet.")
-			return -1
-		}
-		return exitCode
+	// Calling WaitForTermination multiple times is okay, Wait() would error out, but we will get the exit code
+	exited, exitCode := b.WaitForTermination()
+	if !exited {
+		// fmt.Println("Process has not exited yet.")
+		return -1
 	}
-	return b.cmd.ProcessState.ExitCode()
+	return exitCode
 }
 
 func (b *ShellExecutable) writeAndReadReflection(command string) error {

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -141,6 +141,21 @@ func (b *ShellExecutable) WaitForTermination() (hasTerminated bool, exitCode int
 	}
 }
 
+func (b *ShellExecutable) ExitCode() int {
+	if b.cmd.ProcessState == nil {
+		// We are okay with waiting here,
+		// Since if the user's shell is still running, read would have timed out
+		// If it didn't time out, it means the program has exited, that's why we are here
+		exited, exitCode := b.WaitForTermination()
+		if !exited {
+			// fmt.Println("Process has not exited yet.")
+			return -1
+		}
+		return exitCode
+	}
+	return b.cmd.ProcessState.ExitCode()
+}
+
 func (b *ShellExecutable) writeAndReadReflection(command string) error {
 	b.pty.Write([]byte(command + "\n"))
 

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -54,7 +54,7 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 		if errors.Is(err, shell_executable.ErrConditionNotMet) {
 			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q", string(cleanedOutput))
 		} else if errors.Is(err, shell_executable.ErrProgramExited) {
-			return fmt.Errorf("Expected shell to be a long-running process, but it exited")
+			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q, and your program exited with code: %d", string(cleanedOutput), shell.ExitCode())
 		}
 		return err
 	}

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -54,9 +54,13 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 		if errors.Is(err, shell_executable.ErrConditionNotMet) {
 			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q", string(cleanedOutput))
 		} else if errors.Is(err, shell_executable.ErrProgramExited) {
-			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program exited with code %d", string(cleanedOutput), shell.ExitCode())
+			exitCode := shell.ExitCode()
+			if exitCode == -1 {
+				return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program is still running", string(cleanedOutput))
+			} else {
+				return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program exited with code %d", string(cleanedOutput), exitCode)
+			}
 		}
-		return err
 	}
 
 	if !t.ExpectedPattern.Match(cleanedOutput) {

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -54,7 +54,7 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 		if errors.Is(err, shell_executable.ErrConditionNotMet) {
 			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q", string(cleanedOutput))
 		} else if errors.Is(err, shell_executable.ErrProgramExited) {
-			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q, and your program exited with code: %d", string(cleanedOutput), shell.ExitCode())
+			return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program exited with code %d", string(cleanedOutput), shell.ExitCode())
 		}
 		return err
 	}

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -56,7 +56,7 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 		} else if errors.Is(err, shell_executable.ErrProgramExited) {
 			exitCode := shell.ExitCode()
 			if exitCode == -1 {
-				return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program is still running", string(cleanedOutput))
+				return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q", string(cleanedOutput))
 			} else {
 				return fmt.Errorf("Expected first line of output to end with '\\n' (newline), got %q. Program exited with code %d", string(cleanedOutput), exitCode)
 			}


### PR DESCRIPTION
The first commit in this pull request adds the `ExitCode` method to the `ShellExecutable` class. This method allows users to retrieve the exit code of the shell process. The second commit updates the error message displayed when encountering an EOF while reading the response. Additionally, it includes the exit code of the shell process in the error message when the first line of output does not end with a newline character.