### PR TITLE
Improve error message in SingleLineOutputTestCase

### DIFF
--- a/internal/stage6.go
+++ b/internal/stage6.go
@@ -38,6 +38,7 @@ func testType1(stageHarness *test_case_harness.TestCaseHarness) error {
 	for _, invalidCommand := range invalidCommands {
 		command := fmt.Sprintf("type %s", invalidCommand)
 
+		// ToDo: Should be match not contains
 		testCase := test_cases.SingleLineOutputTestCase{
 			Command:                    command,
 			ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^(bash: type: )?%s[:]? not found$`, invalidCommand)),


### PR DESCRIPTION
This pull request refactors the code to improve the error message for output mismatch in the SingleLineOutputTestCase.