### PR TITLE
Refactor test case structure and improve error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.3
 require (
 	github.com/codecrafters-io/tester-utils v0.2.38
 	github.com/creack/pty v1.1.23
+	github.com/fatih/color v1.17.0
 	go.chromium.org/luci v0.0.0-20240530183920-783ca64715fa
 )
 
@@ -15,7 +16,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.17.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/internal/stage10.go
+++ b/internal/stage10.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -31,10 +30,10 @@ func testCd1(stageHarness *test_case_harness.TestCaseHarness) error {
 	directory = "/non-existing-directory"
 	command := fmt.Sprintf("cd %s", directory)
 
-	failureTestCase := test_cases.SingleLineOutputTestCase{
+	failureTestCase := test_cases.SingleLineExactMatchTestCase{
 		Command:                    command,
-		ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^(can't cd to %s|((bash: )?cd: )?%s: No such file or directory)$`, directory, directory)),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", fmt.Sprintf(`cd: %s: No such file or directory`, directory)),
+		ExpectedPattern:            fmt.Sprintf(`^(can't cd to %s|((bash: )?cd: )?%s: No such file or directory)$`, directory, directory),
+		ExpectedPatternExplanation: fmt.Sprintf(`cd: %s: No such file or directory`, directory),
 		SuccessMessage:             "Received error message",
 	}
 

--- a/internal/stage2.go
+++ b/internal/stage2.go
@@ -1,9 +1,6 @@
 package internal
 
 import (
-	"fmt"
-	"regexp"
-
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -17,10 +14,10 @@ func testMissingCommand(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	testCase := test_cases.SingleLineOutputTestCase{
+	testCase := test_cases.SingleLineExactMatchTestCase{
 		Command:                    "nonexistent",
-		ExpectedPattern:            regexp.MustCompile(`^(bash: )?nonexistent: (command )?not found$`),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", "nonexistent: command not found"),
+		ExpectedPattern:            `^(bash: )?nonexistent: (command )?not found$`,
+		ExpectedPatternExplanation: "nonexistent: command not found",
 		SuccessMessage:             "Received command not found message",
 	}
 

--- a/internal/stage3.go
+++ b/internal/stage3.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
@@ -24,10 +23,10 @@ func testREPL(stageHarness *test_case_harness.TestCaseHarness) error {
 	for i := 0; i < numberOfCommands; i++ {
 		command := "invalid_command_" + strconv.Itoa(i+1)
 
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLinePatternMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^(bash: )?%s: (command )?not found$`, command)),
-			ExpectedPatternExplanation: fmt.Sprintf("contain %q", fmt.Sprintf("%s: command not found", command)),
+			ExpectedPattern:            fmt.Sprintf(`^(bash: )?%s: (command )?not found$`, command),
+			ExpectedPatternExplanation: fmt.Sprintf("%s: command not found", command),
 			SuccessMessage:             "Received command not found message",
 		}
 

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -21,10 +20,10 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// We test a nonexistent command first, just to make sure the logic works in a "loop"
-	testCase := test_cases.SingleLineOutputTestCase{
+	testCase := test_cases.SingleLineExactMatchTestCase{
 		Command:                    "invalid_command_1",
-		ExpectedPattern:            regexp.MustCompile(`^(bash: )?invalid_command_1: (command )?not found$`),
-		ExpectedPatternExplanation: fmt.Sprintf("contain %q", "invalid_command_1: command not found"),
+		ExpectedPattern:            `^(bash: )?invalid_command_1: (command )?not found$`,
+		ExpectedPatternExplanation: "invalid_command_1: command not found",
 		SuccessMessage:             "Received command not found message",
 	}
 

--- a/internal/stage5.go
+++ b/internal/stage5.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
@@ -25,10 +24,10 @@ func testEcho(stageHarness *test_case_harness.TestCaseHarness) error {
 		words := strings.Join(random.RandomWords(random.RandomInt(2, 4)), " ")
 		command := fmt.Sprintf("echo %s", words)
 
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLineExactMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^%s$`, words)),
-			ExpectedPatternExplanation: fmt.Sprintf("match %q", words),
+			ExpectedPattern:            fmt.Sprintf(`^%s$`, words),
+			ExpectedPatternExplanation: words,
 			SuccessMessage:             "Received expected response",
 		}
 		if err := testCase.Run(shell, logger); err != nil {

--- a/internal/stage6.go
+++ b/internal/stage6.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -22,10 +21,10 @@ func testType1(stageHarness *test_case_harness.TestCaseHarness) error {
 	for _, builtIn := range builtIns {
 		command := fmt.Sprintf("type %s", builtIn)
 
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLineExactMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^%s is a( special)? shell builtin$`, builtIn)),
-			ExpectedPatternExplanation: fmt.Sprintf("match %q", fmt.Sprintf(`%s is a shell builtin`, builtIn)),
+			ExpectedPattern:            fmt.Sprintf(`^%s is a( special)? shell builtin$`, builtIn),
+			ExpectedPatternExplanation: fmt.Sprintf(`%s is a shell builtin`, builtIn),
 			SuccessMessage:             "Received expected response",
 		}
 		if err := testCase.Run(shell, logger); err != nil {
@@ -38,10 +37,10 @@ func testType1(stageHarness *test_case_harness.TestCaseHarness) error {
 	for _, invalidCommand := range invalidCommands {
 		command := fmt.Sprintf("type %s", invalidCommand)
 
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLineExactMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^(bash: type: )?%s[:]? not found$`, invalidCommand)),
-			ExpectedPatternExplanation: fmt.Sprintf("contain %q", fmt.Sprintf(`%s: not found`, invalidCommand)),
+			ExpectedPattern:            fmt.Sprintf(`^(bash: type: )?%s[:]? not found$`, invalidCommand),
+			ExpectedPatternExplanation: fmt.Sprintf("%s: not found", invalidCommand),
 			SuccessMessage:             "Received expected response",
 		}
 		if err := testCase.Run(shell, logger); err != nil {

--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 
 	"github.com/codecrafters-io/shell-tester/internal/custom_executable"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
@@ -53,11 +52,10 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 			expectedPath = path
 		}
 
-		expectedPattern := fmt.Sprintf(`^(%s is )?%s$`, executable, expectedPath)
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLineExactMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(expectedPattern),
-			ExpectedPatternExplanation: fmt.Sprintf("match %q", fmt.Sprintf(`%s is %s`, executable, expectedPath)),
+			ExpectedPattern:            fmt.Sprintf(`^(%s is )?%s$`, executable, expectedPath),
+			ExpectedPatternExplanation: fmt.Sprintf(`%s is %s`, executable, expectedPath),
 			SuccessMessage:             "Received expected response",
 		}
 		if err := testCase.Run(shell, logger); err != nil {
@@ -69,11 +67,10 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	for _, executable := range nonAvailableExecutables {
 		command := fmt.Sprintf("type %s", executable)
-		expectedPattern := fmt.Sprintf(`^(bash: type: )?%s: not found$`, executable)
-		testCase := test_cases.SingleLineOutputTestCase{
+		testCase := test_cases.SingleLineExactMatchTestCase{
 			Command:                    command,
-			ExpectedPattern:            regexp.MustCompile(expectedPattern),
-			ExpectedPatternExplanation: fmt.Sprintf("match %q", fmt.Sprintf(`%s: not found`, executable)),
+			ExpectedPattern:            fmt.Sprintf(`^(bash: type: )?%s: not found$`, executable),
+			ExpectedPatternExplanation: fmt.Sprintf(`%s: not found`, executable),
 			SuccessMessage:             "Received expected response",
 		}
 		if err := testCase.Run(shell, logger); err != nil {

--- a/internal/stage8.go
+++ b/internal/stage8.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/custom_executable"
@@ -43,12 +42,10 @@ func testRun(stageHarness *test_case_harness.TestCaseHarness) error {
 		"my_exe", randomName,
 	}
 
-	expectedResponseRegex := fmt.Sprintf("^Hello %s! The secret code is %s.$", randomName, randomCode)
-	expectedResponse := fmt.Sprintf("Hello %s! The secret code is %s.", randomName, randomCode)
-	testCase := test_cases.SingleLineOutputTestCase{
+	testCase := test_cases.SingleLineExactMatchTestCase{
 		Command:                    strings.Join(command, " "),
-		ExpectedPattern:            regexp.MustCompile(expectedResponseRegex),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", expectedResponse),
+		ExpectedPattern:            fmt.Sprintf("^Hello %s! The secret code is %s.$", randomName, randomCode),
+		ExpectedPatternExplanation: fmt.Sprintf("Hello %s! The secret code is %s.", randomName, randomCode),
 		SuccessMessage:             "Received expected response",
 	}
 	if err := testCase.Run(shell, logger); err != nil {

--- a/internal/stage9.go
+++ b/internal/stage9.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
@@ -25,10 +24,10 @@ func testpwd(stageHarness *test_case_harness.TestCaseHarness) error {
 		return fmt.Errorf("CodeCrafters internal error. Error getting cwd: %v", err)
 	}
 
-	testCase := test_cases.SingleLineOutputTestCase{
+	testCase := test_cases.SingleLineExactMatchTestCase{
 		Command:                    "type pwd",
-		ExpectedPattern:            regexp.MustCompile(`^pwd is a( special)? shell builtin$`),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", `pwd is a shell builtin`),
+		ExpectedPattern:            `^pwd is a( special)? shell builtin$`,
+		ExpectedPatternExplanation: `pwd is a shell builtin`,
 		SuccessMessage:             "Received 'pwd is a shell builtin'",
 	}
 	if err := testCase.Run(shell, logger); err != nil {
@@ -62,10 +61,10 @@ func testpwd(stageHarness *test_case_harness.TestCaseHarness) error {
 		}(exec.Command("sh", "-c", revertCommand))
 	}
 
-	testCase = test_cases.SingleLineOutputTestCase{
+	testCase = test_cases.SingleLineExactMatchTestCase{
 		Command:                    "pwd",
-		ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^%s$`, cwd)),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", cwd),
+		ExpectedPattern:            fmt.Sprintf(`^%s$`, cwd),
+		ExpectedPatternExplanation: cwd,
 		SuccessMessage:             "Received current working directory response",
 	}
 	if err := testCase.Run(shell, logger); err != nil {

--- a/internal/test_cases/cd_test_case.go
+++ b/internal/test_cases/cd_test_case.go
@@ -3,7 +3,6 @@ package test_cases
 import (
 	"fmt"
 	"os"
-	"regexp"
 
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -38,10 +37,10 @@ func (t *CDAndPWDTestCase) Run(shell *shell_executable.ShellExecutable, logger *
 	nextCommand := "pwd"
 
 	// Next we send pwd and check that the directory we cd'ed into is the response
-	testCase := SingleLineOutputTestCase{
+	testCase := SingleLineExactMatchTestCase{
 		Command:                    nextCommand,
-		ExpectedPattern:            regexp.MustCompile(fmt.Sprintf(`^%s$`, t.Response)),
-		ExpectedPatternExplanation: fmt.Sprintf("match %q", t.Response),
+		ExpectedPattern:            fmt.Sprintf(`^%s$`, t.Response),
+		ExpectedPatternExplanation: t.Response,
 		SuccessMessage:             "Received current working directory response",
 	}
 	if err := testCase.Run(shell, logger); err != nil {

--- a/internal/test_cases/single_line_exact_match_output_test_case.go
+++ b/internal/test_cases/single_line_exact_match_output_test_case.go
@@ -1,0 +1,65 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+	"github.com/fatih/color"
+)
+
+// SingleLineExactMatchTestCase verifies a prompt exists, sends a command and matches the output against a string.
+type SingleLineExactMatchTestCase struct {
+	// The command to execute (the command's output will be matched against ExpectedPattern)
+	Command string
+
+	// ExpectedPattern is the regex that is evaluated against the command's output.
+	ExpectedPattern string
+
+	// ExpectedPatternExplanation is used in the error message if the ExpectedPattern doesn't match the command's output
+	ExpectedPatternExplanation string
+
+	// SuccessMessage is logged if the ExpectedPattern matches the command's output
+	SuccessMessage string
+}
+
+func (t SingleLineExactMatchTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	singleLineOutputTestCase := SingleLineOutputTestCase{
+		Command:        t.Command,
+		Validator:      BuildExactMatchValidator(t.ExpectedPattern, t.ExpectedPatternExplanation),
+		SuccessMessage: t.SuccessMessage,
+	}
+
+	return singleLineOutputTestCase.Run(shell, logger)
+
+}
+
+func BuildExactMatchValidator(pattern string, simplifiedPatternExplanation string) func([]byte) error {
+	re := regexp.MustCompile(pattern)
+	return func(output []byte) error {
+		if !re.Match(output) {
+			return fmt.Errorf(BuildColoredErrorMessage(simplifiedPatternExplanation, string(output)))
+		}
+		return nil
+	}
+}
+
+func colorizeString(colorToUse color.Attribute, msg string) string {
+	c := color.New(colorToUse)
+	return c.Sprint(msg)
+}
+
+func BuildColoredErrorMessage(expectedPatternExplanation string, cleanedOutput string) string {
+	indent := 9 - 4
+
+	errorMsg := "Expected:" // 9
+	errorMsg += " " + colorizeString(color.FgGreen, expectedPatternExplanation)
+	errorMsg += "\n"
+	errorMsg += strings.Repeat(" ", indent)
+	errorMsg += "Got:" // 4
+	errorMsg += " " + colorizeString(color.FgRed, cleanedOutput)
+
+	return errorMsg
+}

--- a/internal/test_cases/single_line_exact_match_output_test_case.go
+++ b/internal/test_cases/single_line_exact_match_output_test_case.go
@@ -26,7 +26,7 @@ type SingleLineExactMatchTestCase struct {
 }
 
 func (t SingleLineExactMatchTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
-	singleLineOutputTestCase := SingleLineOutputTestCase{
+	singleLineOutputTestCase := singleLineOutputTestCase{
 		Command:        t.Command,
 		Validator:      BuildExactMatchValidator(t.ExpectedPattern, t.ExpectedPatternExplanation),
 		SuccessMessage: t.SuccessMessage,

--- a/internal/test_cases/single_line_exact_match_output_test_case.go
+++ b/internal/test_cases/single_line_exact_match_output_test_case.go
@@ -10,9 +10,10 @@ import (
 	"github.com/fatih/color"
 )
 
-// SingleLineExactMatchTestCase verifies a prompt exists, sends a command and matches the output against a string.
+// SingleLineExactMatchTestCase internally creates a SingleLineOutputTestCase with a validator that matches the output against a pattern.
+// We look for an exact match in this case, so our error logs can take advantage of color to highlight the exact mismatch.
 type SingleLineExactMatchTestCase struct {
-	// The command to execute (the command's output will be matched against ExpectedPattern)
+	// Command is the command to execute, whose output will be matched against ExpectedPattern.
 	Command string
 
 	// ExpectedPattern is the regex that is evaluated against the command's output.

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -11,8 +11,8 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-// SingleLineOutputTestCase verifies a prompt exists, sends a command and matches the output against a string.
-type SingleLineOutputTestCase struct {
+// singleLineOutputTestCase verifies a prompt exists, sends a command and matches the output against a string.
+type singleLineOutputTestCase struct {
 	// The command to execute (the command's output will be matched using the Validator function)
 	Command string
 
@@ -24,7 +24,7 @@ type SingleLineOutputTestCase struct {
 	SuccessMessage string
 }
 
-func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+func (t singleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
 	promptTestCase := NewSilentPromptTestCase("$ ")
 
 	if err := promptTestCase.Run(shell, logger); err != nil {
@@ -62,7 +62,7 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 	}
 
 	if t.Validator == nil {
-		panic("CodeCrafters internal error: No validator provided for SingleLineOutputTestCase")
+		panic("CodeCrafters internal error: No validator provided for singleLineOutputTestCase")
 	}
 
 	if validatorErr := t.Validator(cleanedOutput); validatorErr != nil {

--- a/internal/test_cases/single_line_output_test_case.go
+++ b/internal/test_cases/single_line_output_test_case.go
@@ -13,14 +13,12 @@ import (
 
 // SingleLineOutputTestCase verifies a prompt exists, sends a command and matches the output against a string.
 type SingleLineOutputTestCase struct {
-	// The command to execute (the command's output will be matched against ExpectedPattern)
+	// The command to execute (the command's output will be matched using the Validator function)
 	Command string
 
-	// ExpectedPattern is the regex that is evaluated against the command's output.
-	ExpectedPattern *regexp.Regexp
-
-	// ExpectedPatternExplanation is used in the error message if the ExpectedPattern doesn't match the command's output
-	ExpectedPatternExplanation string
+	// Validator is a function that contains the expected pattern and the expected pattern explanation,
+	// and returns an error if the output does not match the expected pattern.
+	Validator func([]byte) error
 
 	// SuccessMessage is logged if the ExpectedPattern matches the command's output
 	SuccessMessage string
@@ -63,13 +61,17 @@ func (t SingleLineOutputTestCase) Run(shell *shell_executable.ShellExecutable, l
 		}
 	}
 
-	if !t.ExpectedPattern.Match(cleanedOutput) {
+	if t.Validator == nil {
+		panic("CodeCrafters internal error: No validator provided for SingleLineOutputTestCase")
+	}
+
+	if validatorErr := t.Validator(cleanedOutput); validatorErr != nil {
 		// If test fails, we still want to log the rest of the output
 		restOfOutput, err := shell.ReadBytesUntilTimeout(100 * time.Millisecond)
 		if err == nil {
 			shell.LogOutput(sanitizeLogOutput(restOfOutput))
 		}
-		return fmt.Errorf("Expected first line of output to %s, got %q", t.ExpectedPatternExplanation, string(cleanedOutput))
+		return validatorErr
 	}
 
 	logger.Successf("✓ %s", t.SuccessMessage)

--- a/internal/test_cases/single_line_pattern_match_output_test_case.go
+++ b/internal/test_cases/single_line_pattern_match_output_test_case.go
@@ -24,7 +24,7 @@ type SingleLinePatternMatchTestCase struct {
 }
 
 func (t SingleLinePatternMatchTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
-	singleLineOutputTestCase := SingleLineOutputTestCase{
+	singleLineOutputTestCase := singleLineOutputTestCase{
 		Command:        t.Command,
 		Validator:      BuildPatternMatchValidator(t.ExpectedPattern, t.ExpectedPatternExplanation),
 		SuccessMessage: t.SuccessMessage,

--- a/internal/test_cases/single_line_pattern_match_output_test_case.go
+++ b/internal/test_cases/single_line_pattern_match_output_test_case.go
@@ -1,0 +1,45 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+// SingleLinePatternMatchTestCase verifies a prompt exists, sends a command and matches the output against a string.
+type SingleLinePatternMatchTestCase struct {
+	// The command to execute (the command's output will be matched against ExpectedPattern)
+	Command string
+
+	// ExpectedPattern is the regex that is evaluated against the command's output.
+	ExpectedPattern string
+
+	// ExpectedPatternExplanation is used in the error message if the ExpectedPattern doesn't match the command's output
+	ExpectedPatternExplanation string
+
+	// SuccessMessage is logged if the ExpectedPattern matches the command's output
+	SuccessMessage string
+}
+
+func (t SingleLinePatternMatchTestCase) Run(shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	singleLineOutputTestCase := SingleLineOutputTestCase{
+		Command:        t.Command,
+		Validator:      BuildPatternMatchValidator(t.ExpectedPattern, t.ExpectedPatternExplanation),
+		SuccessMessage: t.SuccessMessage,
+	}
+
+	return singleLineOutputTestCase.Run(shell, logger)
+
+}
+
+func BuildPatternMatchValidator(pattern string, simplifiedPatternExplanation string) func([]byte) error {
+	re := regexp.MustCompile(pattern)
+	return func(output []byte) error {
+		if !re.Match(output) {
+			return fmt.Errorf("Expected first line of output to contain %s, got %q", simplifiedPatternExplanation, string(output))
+		}
+		return nil
+	}
+}

--- a/internal/test_cases/single_line_pattern_match_output_test_case.go
+++ b/internal/test_cases/single_line_pattern_match_output_test_case.go
@@ -8,9 +8,10 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-// SingleLinePatternMatchTestCase verifies a prompt exists, sends a command and matches the output against a string.
+// SingleLinePatternMatchTestCase internally creates a SingleLineOutputTestCase with a validator that matches the output against a pattern.
+// We look for a partial `contains` match in this case.
 type SingleLinePatternMatchTestCase struct {
-	// The command to execute (the command's output will be matched against ExpectedPattern)
+	// Command is the command to execute, whose output will be matched against ExpectedPattern.
 	Command string
 
 	// ExpectedPattern is the regex that is evaluated against the command's output.

--- a/internal/test_helpers/fixtures/missing_command/wrong_output
+++ b/internal/test_helpers/fixtures/missing_command/wrong_output
@@ -5,6 +5,7 @@ Debug = true
 [33m[your-program] [0m$ 
 [33m[stage-2] [0m[94m> nonexistent[0m
 [33m[your-program] [0mCommand: nonexistent
-[33m[stage-2] [0m[91mExpected: [32mnonexistent: command not found[0m[0m
-[33m[stage-2] [0m[91m     Got: [31mCommand: nonexistent[0m[0m
+[33m[stage-2] [0m[94m[32mExpected:[0m "nonexistent: command not found"[0m
+[33m[stage-2] [0m[94m[31mReceived:[0m "Command: nonexistent"[0m
+[33m[stage-2] [0m[91mReceived output does not match expectation.[0m
 [33m[stage-2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/missing_command/wrong_output
+++ b/internal/test_helpers/fixtures/missing_command/wrong_output
@@ -5,5 +5,6 @@ Debug = true
 [33m[your-program] [0m$ 
 [33m[stage-2] [0m[94m> nonexistent[0m
 [33m[your-program] [0mCommand: nonexistent
-[33m[stage-2] [0m[91mExpected first line of output to match "nonexistent: command not found", got "Command: nonexistent"[0m
+[33m[stage-2] [0m[91mExpected: [32mnonexistent: command not found[0m[0m
+[33m[stage-2] [0m[91m     Got: [31mCommand: nonexistent[0m[0m
 [33m[stage-2] [0m[91mTest failed[0m


### PR DESCRIPTION
This PR refactors how we handle pattern matching in test cases to provide better error messages and cleaner code organization.

Key changes:

- Split SingleLineOutputTestCase into three specialized test case types:

- SingleLineExactMatchTestCase - For exact string matches with colored diff output

- SingleLinePatternMatchTestCase - For regex pattern matching with simple diff output

- Base singleLineOutputTestCase - Internal implementation shared by both

- Improved error message formatting:

- Added color coding (green for expected, red for actual output)

- Better visual alignment and readability

- More consistent error message structure

- Code cleanup:

- Removed duplicate regexp imports across multiple files

- Simplified pattern matching logic

- Made the base test case type private since it's an implementation detail

- Dependencies:

- Promoted github.com/fatih/color from indirect to direct dependency for colored error messages

These changes make test failures more readable and maintainable while reducing code duplication. The colored output will help developers quickly identify differences between expected and actual output.

No functional changes to the testing behavior - this is purely a refactoring for better developer experience.