### PR TITLE
Fix dynamic retrieval of 'cat' executable location

### DIFF
--- a/internal/stage_q6.go
+++ b/internal/stage_q6.go
@@ -3,7 +3,9 @@ package internal
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/custom_executable"
@@ -42,7 +44,11 @@ func testQ6(stageHarness *test_case_harness.TestCaseHarness) error {
 	executableName3 := `"exe with \'single quotes\'"`
 	executableName4 := `'exe with \n newline'`
 
-	err = custom_executable.CopyExecutableToMultiplePaths("/usr/bin/cat", []string{path.Join(randomDir, executableName1), path.Join(randomDir, executableName2), path.Join(randomDir, executableName3), path.Join(randomDir, executableName4)}, logger)
+	originalExecutablePath, err := getLocationOfExecutable("cat")
+	if err != nil {
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Cannot get location of cat executable on %s/%s", runtime.GOOS, runtime.GOARCH))
+	}
+	err = custom_executable.CopyExecutableToMultiplePaths(originalExecutablePath, []string{path.Join(randomDir, executableName1), path.Join(randomDir, executableName2), path.Join(randomDir, executableName3), path.Join(randomDir, executableName4)}, logger)
 	if err != nil {
 		panic("CodeCrafters Internal Error: Cannot copy executable")
 	}
@@ -80,4 +86,12 @@ func testQ6(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	return assertShellIsRunning(shell, logger)
+}
+
+func getLocationOfExecutable(executableName string) (string, error) {
+	executablePath, err := exec.LookPath(executableName)
+	if err != nil {
+		return "", err
+	}
+	return executablePath, nil
 }


### PR DESCRIPTION
This pull request fixes an issue with the testQ6 function by updating it to dynamically retrieve the location of the 'cat' executable. It introduces a new function, getLocationOfExecutable, for improved executable path management. The original executable path is obtained using the exec.LookPath function, and if it cannot be found, an error is returned. This ensures that the testQ6 function can handle errors and retrieve the correct location of the 'cat' executable.