### PR TITLE
Refactor 'cat' executable retrieval

### DIFF
--- a/internal/stage_q6.go
+++ b/internal/stage_q6.go
@@ -3,9 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
-	"runtime"
 	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/custom_executable"
@@ -44,10 +42,12 @@ func testQ6(stageHarness *test_case_harness.TestCaseHarness) error {
 	executableName3 := `"exe with \'single quotes\'"`
 	executableName4 := `'exe with \n newline'`
 
-	originalExecutablePath, err := getLocationOfExecutable("cat")
+	originalExecutablePath := "/tmp/catexe"
+	err = createExecutableCallingCat(originalExecutablePath)
 	if err != nil {
-		panic(fmt.Sprintf("CodeCrafters Internal Error: Cannot get location of cat executable on %s/%s", runtime.GOOS, runtime.GOARCH))
+		panic("CodeCrafters Internal Error: Cannot create executable")
 	}
+
 	err = custom_executable.CopyExecutableToMultiplePaths(originalExecutablePath, []string{path.Join(randomDir, executableName1), path.Join(randomDir, executableName2), path.Join(randomDir, executableName3), path.Join(randomDir, executableName4)}, logger)
 	if err != nil {
 		panic("CodeCrafters Internal Error: Cannot copy executable")
@@ -88,10 +88,12 @@ func testQ6(stageHarness *test_case_harness.TestCaseHarness) error {
 	return assertShellIsRunning(shell, logger)
 }
 
-func getLocationOfExecutable(executableName string) (string, error) {
-	executablePath, err := exec.LookPath(executableName)
-	if err != nil {
-		return "", err
-	}
-	return executablePath, nil
+func createExecutableFile(path string, contents string) error {
+	return os.WriteFile(path, []byte(contents), 0o755)
+}
+
+func createExecutableCallingCat(path string) error {
+	content := `#!/bin/sh
+exec cat "$@"`
+	return createExecutableFile(path, content)
 }

--- a/internal/stage_q6.go
+++ b/internal/stage_q6.go
@@ -42,7 +42,7 @@ func testQ6(stageHarness *test_case_harness.TestCaseHarness) error {
 	executableName3 := `"exe with \'single quotes\'"`
 	executableName4 := `'exe with \n newline'`
 
-	originalExecutablePath := "/tmp/catexe"
+	originalExecutablePath := "/tmp/custom_cat_executable"
 	err = createExecutableCallingCat(originalExecutablePath)
 	if err != nil {
 		panic("CodeCrafters Internal Error: Cannot create executable")

--- a/internal/test_helpers/fixtures/quoting/pass
+++ b/internal/test_helpers/fixtures/quoting/pass
@@ -122,10 +122,10 @@ Debug = true
 
 [33m[stage-1] [0m[94mRunning tests for Stage #1: qj0[0m
 [33m[stage-1] [0m[94mRunning ./your_shell.sh[0m
-[33m[stage-1] [0m[94mCopying /usr/bin/cat to /tmp/foo/'exe  with  space'[0m
-[33m[stage-1] [0m[94mCopying /usr/bin/cat to /tmp/foo/'exe with "quotes"'[0m
-[33m[stage-1] [0m[94mCopying /usr/bin/cat to /tmp/foo/"exe with \'single quotes\'"[0m
-[33m[stage-1] [0m[94mCopying /usr/bin/cat to /tmp/foo/'exe with \n newline'[0m
+[33m[stage-1] [0m[94mCopying /tmp/custom_cat_executable to /tmp/foo/'exe  with  space'[0m
+[33m[stage-1] [0m[94mCopying /tmp/custom_cat_executable to /tmp/foo/'exe with "quotes"'[0m
+[33m[stage-1] [0m[94mCopying /tmp/custom_cat_executable to /tmp/foo/"exe with \'single quotes\'"[0m
+[33m[stage-1] [0m[94mCopying /tmp/custom_cat_executable to /tmp/foo/'exe with \n newline'[0m
 [33m[stage-1] [0m[94mWriting file "/tmp/foo/f1" with content "raspberry blueberry."[0m
 [33m[stage-1] [0m[94mWriting file "/tmp/foo/f2" with content "apple pineapple."[0m
 [33m[stage-1] [0m[94mWriting file "/tmp/foo/f3" with content "strawberry raspberry."[0m


### PR DESCRIPTION
This pull request refactors the code to replace the dynamic retrieval of the 'cat' executable with a custom executable. The previous implementation used the `exec.LookPath` function to locate the 'cat' executable, but this caused issues. The new implementation creates a custom executable file that calls the 'cat' command. This change improves the reliability and stability of the code.