### PR TITLE
Add an important test case in stage_q2

### DIFF
--- a/internal/stage_q2.go
+++ b/internal/stage_q2.go
@@ -39,12 +39,14 @@ func testQ2(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	L := random.RandomElementsFromArray(LARGE_WORDS, 5)
 	inputs := []string{
+		fmt.Sprintf(`echo "%s"'%s'`, L[0], L[3]),
 		fmt.Sprintf(`echo "%s %s"`, L[0], L[1]),
 		fmt.Sprintf(`echo "%s  %s"  "%s"`, L[1], L[2], L[3]),
 		fmt.Sprintf(`echo "%s"  "%s's"  "%s"`, L[3], L[4], L[1]),
 		fmt.Sprintf(`cat "%s" "%s" "%s"`, filePaths[0], filePaths[1], filePaths[2]),
 	}
 	expectedOutputs := []string{
+		fmt.Sprintf("%s%s", L[0], L[3]),
 		fmt.Sprintf("%s %s", L[0], L[1]),
 		fmt.Sprintf("%s  %s %s", L[1], L[2], L[3]),
 		fmt.Sprintf(`%s %s's %s`, L[3], L[4], L[1]),


### PR DESCRIPTION
I have added a new test case where my implementation was failing, but it was passing the tester.

As this is a pretty common case, I have added it to the tester:

echo "apple"'banana' // Here single quote string is after a double quote string. It could be vise-versa also. 

The output should be this:

applebanana

But my implementation of shell was giving:

apple'banana' // It missed the single quote, because of a bug in my implementation

I think this test case is a basic one and should be included.