### PR TITLE
paul assert 2

### DIFF
--- a/internal/assertions/assertion.go
+++ b/internal/assertions/assertion.go
@@ -1,22 +1,11 @@
 package assertions
 
-// BaseAssertion contains elements mandatory to all assertions.
-type BaseAssertion struct {
-	// screenAsserter is the ScreenAsserter that contains the rendered screenstate
-	screenAsserter *ScreenAsserter
-
-	// rowIndex is the index of the row in the screenstate that we want to assert on
-	rowIndex int
-
-	// Each assertion should update the row index in screenAsserter atmost once
-	// Once it performs the update, it should set this flag to true
-	ifUpdatedRowIndex bool
+type AssertionError struct {
+	StartRowIndex int
+	ErrorRowIndex int
+	Message       string
 }
 
 type Assertion interface {
-	Run() error
-	WrappedRun() bool
-	GetRowUpdateCount() int
-	UpdateRowIndex()
-	GetType() string
+	Run(screenState [][]string, startRowIndex int) (processedRowCount int, err error)
 }

--- a/internal/assertions/prompt_assertion.go
+++ b/internal/assertions/prompt_assertion.go
@@ -9,48 +9,27 @@ import (
 
 // PromptTestCase verifies a prompt exists, and that there's no extra output after it.
 type PromptAssertion struct {
-	BaseAssertion
-
 	// expectedPrompt is the prompt expected to be displayed (example: "$ ")
 	expectedPrompt string
 }
 
-func NewPromptAssertion(screenAsserter *ScreenAsserter, rowIndex int, expectedPrompt string) PromptAssertion {
-	return PromptAssertion{BaseAssertion: BaseAssertion{screenAsserter: screenAsserter, rowIndex: rowIndex}, expectedPrompt: expectedPrompt}
+func NewPromptAssertion(expectedPrompt string) PromptAssertion {
+	return PromptAssertion{expectedPrompt: expectedPrompt}
 }
 
-func (t *PromptAssertion) Run() error {
-	screen := t.screenAsserter.Shell.GetScreenState()
-	if len(screen) == 0 {
+func (t *PromptAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err error) {
+	if len(screenState) == 0 {
 		return fmt.Errorf("expected screen to have at least one row, but it was empty")
 	}
-	rawRow := screen[t.rowIndex]
+
+	rawRow := screenState[startRowIndex]
 	cleanedRow := utils.BuildCleanedRow(rawRow)
 
 	if !strings.EqualFold(cleanedRow, t.expectedPrompt) {
-		return fmt.Errorf("expected prompt to be %q, but got %q", t.expectedPrompt, cleanedRow)
+		return 0, fmt.Errorf("expected prompt to be %q, but got %q", t.expectedPrompt, cleanedRow)
 	}
 
-	return nil
-}
-
-func (t *PromptAssertion) WrappedRun() bool {
-	// True if the prompt assertion is a success
-	return t.Run() == nil
-}
-
-func (t *PromptAssertion) GetRowUpdateCount() int {
-	return 0
-}
-
-func (t *PromptAssertion) UpdateRowIndex() {
-	// Prompts are always on the same line, so we don't need to update the row index
-	if t.ifUpdatedRowIndex {
-		return
-	}
-	t.screenAsserter.UpdateRowIndex(t.GetRowUpdateCount())
-	t.ifUpdatedRowIndex = true
-	// fmt.Println("PromptAssertion.UpdateRowIndex() called, leading to row index", t.screenAsserter.GetRowIndex())
+	return 0, nil
 }
 
 func (t *PromptAssertion) GetType() string {

--- a/internal/stage2.go
+++ b/internal/stage2.go
@@ -1,11 +1,8 @@
 package internal
 
 import (
-	"regexp"
-
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
-	"github.com/codecrafters-io/shell-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -18,34 +15,67 @@ func testMissingCommand(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	screenAsserter := assertions.NewScreenAsserter(shell, logger)
-	promptAssertion := screenAsserter.PromptAssertion(0, "$ ")
-	screenAsserter.AddAssertion(&promptAssertion)
 
-	responseTestCase := test_cases.NewResponseTestCase()
-
-	if err := responseTestCase.Run(screenAsserter, true); err != nil {
+	// Checks if prompt is present
+	if err := screenAsserter.Run(); err != nil {
 		return err
 	}
 
-	screenAsserter.ClearAssertions()
-	firstLineAssertion := screenAsserter.SingleLineAssertion(0, "$ nonexistent", nil, "nonexistent")
-	screenAsserter.AddAssertion(&firstLineAssertion)
-	commandResponseTestCase := test_cases.NewCommandResponseTestCase("nonexistent")
-	if err := commandResponseTestCase.Run(screenAsserter, true); err != nil {
+	// TODO: Can shorten into a SingleLineCommandTestCase
+	// ------ Test case starts
+	shell.SendCommand("nonexistent")
+	screenAsserter.AddAssertion(screenAsserter.SingleLineAssertion(0, "$ nonexistent", nil, "nonexistent"))
+	screenAsserter.AddAssertion(screenAsserter.SingleLineAssertion(1, "", nil, "nonexistent: command not found"))
+
+
+	if err := screenAsserter.Run(); err != nil {
 		return err
 	}
+	// ------ Test case ends
 
-	secondLineAssertion := screenAsserter.SingleLineAssertion(1, "", []*regexp.Regexp{regexp.MustCompile(`bash: nonexistent: command not found`)}, "nonexistent: command not found")
-	screenAsserter.AddAssertion(&secondLineAssertion)
+	// if err := screenAsserter.RunWithoutLastPromptAssertion(); err != nil {
+	// 	return err
+	// }
 
-	// At this stage the user might or might not have implemented a REPL to print the prompt again, so we won't test further
-	// ToDo: Remove this prompt assertion from here
-	promptAssertion = screenAsserter.PromptAssertion(2, "$ ")
-	screenAsserter.AddAssertion(&promptAssertion)
+	// [x] Assert prompt is printed
+	// [x] Send command_1
+	// [x] Assert "$ command_1" is present
+	// [] Assert next line "command_1: not found" is present
+	// [] Assert prompt is printed again
+	// [] Send command_2
+	// [] Assert "$ command_2" is present
+	// [] Assert next line "command_2: not found" is present
+	// [] Assert prompt is printed again
 
-	if err := responseTestCase.Run(screenAsserter, true); err != nil {
-		return err
-	}
+	// screenAsserter := assertions.NewScreenAsserter(shell, logger)
+	// promptAssertion := screenAsserter.PromptAssertion(0, "$ ")
+	// screenAsserter.AddAssertion(&promptAssertion)
+
+	// responseTestCase := test_cases.NewResponseTestCase()
+
+	// if err := responseTestCase.Run(screenAsserter, true); err != nil {
+	// 	return err
+	// }
+
+	// screenAsserter.ClearAssertions()
+	// firstLineAssertion := screenAsserter.SingleLineAssertion(0, "$ nonexistent", nil, "nonexistent")
+	// screenAsserter.AddAssertion(&firstLineAssertion)
+	// commandResponseTestCase := test_cases.NewCommandResponseTestCase("nonexistent")
+	// if err := commandResponseTestCase.Run(screenAsserter, true); err != nil {
+	// 	return err
+	// }
+
+	// secondLineAssertion := screenAsserter.SingleLineAssertion(1, "", []*regexp.Regexp{regexp.MustCompile(`bash: nonexistent: command not found`)}, "nonexistent: command not found")
+	// screenAsserter.AddAssertion(&secondLineAssertion)
+
+	// // At this stage the user might or might not have implemented a REPL to print the prompt again, so we won't test further
+	// // ToDo: Remove this prompt assertion from here
+	// promptAssertion = screenAsserter.PromptAssertion(2, "$ ")
+	// screenAsserter.AddAssertion(&promptAssertion)
+
+	// if err := responseTestCase.Run(screenAsserter, true); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }


### PR DESCRIPTION
- **feat: add interface to vterm**
- **feat: enhance ShellExecutable with virtual terminal support**
- **chore: update go.mod and go.sum to include new indirect dependencies**
- **chore: rename and consolidate bash test targets**
- **chore: update Makefile to use 'make' for bash test targets**
- **feat: add Write functionality to ShellExecutable for ReadBytesUntil methods**
- **feat: add PromptTestCaseVT for verifying prompt output using vt**
- **refactor: log full output**
- **feat: add GetRowsTillEnd method and handle empty Write calls in virtualTerminal**
- **feat: add logging methods for screen state and rows in ShellExecutable**
- **refactor: replace AsyncBytewiseReader with just AsyncReader**
- **refactor: update ConditionReader to use AsyncReader instead of AsyncBytewiseReader and improve byte accumulation logic**
- **refactor: expose VirtualTerminal interface**
- **refactor: rename bytewiseReader to asyncReader in ConditionReader for clarity**
- **feat: implement TermIO for synchronized terminal input/output handling**
- **chore: update dependencies in go.mod and go.sum**
- **refactor: use wrapped termIO, as param to conditionReader**
- **refactor: remove manual writes to vt, as it is now coupled to pty reads**
- **refactor: improve byte accumulation logic in ConditionReader to prevent overshooting**
- **feat: store the read but unprocessed bytes in a buffer for processing in the next call**
- **refactor: enhance byte processing in ConditionReader by consolidating non-accumulated buffer with readBytes for improved condition checking**
- **refactor: push storing unread buffer logic to inside reader implementation**
- **refactor: simplify ConditionReader by removing non-accumulated buffer and integrating unread logic into asyncReader**
- **chore: fix lint issues**
- **feat: add Assertion interface for assertion handling**
- **feat: add base screen state assertion**
- **feat: introduce CompositeScreenStateTestCase**
- **refactor: remove obsolete PromptTestCaseVT**
- **feat: implement SingleLineScreenStateAssertion for row-based output validation**
- **feat: update Assertion interface to include logger and screen state parameters**
- **feat: implement stack-based CompositeScreenStateTestCase with assertion management methods**
- **feat: add SingleLineScreenStateAssertion for validating single row output and enhance term_io with TeeReader**
- **feat: add PromptTestCase and ResponseTestCase for prompt and output validation in shell tests**
- **remove termio**
- **Refactor shell executable methods to simplify output reading and logging.**
- **Refactor GetScreenState methods to remove retainColors parameter and default to false.**
- **Refactor AsyncReader to use Read instead of ReadBytes for improved clarity.**
- **Refactor ReadUntil and ReadUntilTimeout to handle errors more clearly.**
- **chore: comment out broken code**
- **feat: add prompt_assertion**
- **feat: add ScreenAsserter struct for screen assertion functionality**
- **chore: comment out broken code**
- **feat: enhance ScreenAsserter with constructor and logging functionality**
- **refactor: update Assertion interface and implement WrappedRun method in PromptAssertion**
- **draft: implement response test case**
- **refactor: simplify GetScreenState method by removing color handling**
- **refactor: simplify Run method in CompositeScreenStateTestCase by removing unnecessary parameters**
- **refactor: update stage1**
- **refactor: enhance PromptAssertion and ScreenAsserter with screenAsserter parameter and error handling**
- **refactor: update ResponseTestCase to use SilentPromptAssertion with ScreenAsserter**
- **refactor: add test_vt target to Makefile for new test cases**
- **chore: remove unused code**
- **feat: enhance ScreenAsserter with assertion management methods**
- **refactor: update ResponseTestCase and testPrompt to streamline assertion handling**
- **refactor: rename variable for clarity in testPrompt function**
- **feat: add SingleLineAssertion and ClearAssertions methods to ScreenAsserter for improved assertion handling**
- **refactor: simplify SingleLineScreenStateAssertion by removing logger dependency and enhancing error handling**
- **feat: introduce CommandResponseTestCase for shell command output verification**
- **refactor: update error message in ResponseTestCase to improve clarity and consistency**
- **feat: enhance testMissingCommand function with ScreenAsserter for improved command response verification**
- **fix: run condition at the beginning to catch edge cases where we have already read the whole expected thing**
- **refactor: remove command field from ResponseTestCase and update error message for clarity**
- **refactor: improve logging in ScreenAsserter and adjust error handling in SingleLineScreenStateAssertion**
- **feat: enhance ScreenAsserter with row logging and indexing capabilities**
- **feat: add GetRowUpdateCount and UpdateRowIndex methods to assertions for improved row handling**
- **refactor: streamline PromptAssertion and SingleLineAssertion methods in ScreenAsserter to accept a pointer to ScreenAsserter**
- **refactor: update logging in test cases to use LogUptoCurrentRow for better output clarity**
- **refactor: update PromptAssertion and SingleLineAssertion methods to accept a pointer to ScreenAsserter**
- **fix: update when we start logging shell output**
- **refactor: update testMissingCommand function to include prompt assertion and clean up comments**
- **wip: enhance logging in ResponseTestCase to track row indices before and after logging output**
- **feat: introduce BaseAssertion struct to standardize assertion row handling and state management**
- **refactor: integrate BaseAssertion into PromptAssertion for improved state management and streamline row index updates**
- **refactor: simplify LogUptoCurrentRow method, enhance RunAllAssertions to control side effects, and update PromptAssertion and SingleLineAssertion to use constructors for improved clarity and consistency**
- **refactor: add RunAllAssertions call in CommandResponseTestCase and ResponseTestCase to ensure assertions are executed consistently**
- **refactor: integrate BaseAssertion into SingleLineScreenStateAssertion for improved structure and clarity; update constructor to streamline initialization and enhance row index management**
- **feat: add GetType method to Assertion interface and implement it in PromptAssertion and SingleLineScreenStateAssertion for type identification**
- **feat: update ResponseTestCase to conditionally log current row based on prompt assertion**
- **refactor: migrate buildCleanedRow functionality to utils package**
- **refactor: update assertion methods to use pointer receivers for improved performance and consistency**
- **refactor: update ResponseTestCase to utilize utils.BuildCleanedRow for improved output formatting**
- **refactor: simplify PromptAssertion and SingleLineAssertion methods by removing unnecessary parameters**
- **Refactor assertions to use new AssertionError struct and simplify PromptAssertion.**
