### PR TITLE
Add `SkipPromptAssertion` flag to `CommandReflectionTestCase`

### DIFF
--- a/internal/stage2.go
+++ b/internal/stage2.go
@@ -22,10 +22,11 @@ func testInvalidCommand(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	invalidCommand := getRandomInvalidCommand()
 
-	// We are seperating this out because we don't want to assert 
+	// We are seperating this out because we don't want to assert
 	// The prompt at the end
 	testCase := test_cases.CommandReflectionTestCase{
-		Command: invalidCommand,
+		Command:             invalidCommand,
+		SkipPromptAssertion: true,
 	}
 	if err := testCase.Run(asserter, shell, logger, true); err != nil {
 		return err

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -38,7 +38,8 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	refTestCase := test_cases.CommandReflectionTestCase{
-		Command: "exit 0",
+		Command:             "exit 0",
+		SkipPromptAssertion: true,
 	}
 	if err := refTestCase.Run(asserter, shell, logger, true); err != nil {
 		return err

--- a/internal/test_cases/cd_test_case.go
+++ b/internal/test_cases/cd_test_case.go
@@ -27,7 +27,8 @@ func (t *CDAndPWDTestCase) Run(asserter *logged_shell_asserter.LoggedShellAssert
 
 	// And send the cd command, we don't expect any response
 	tc := CommandReflectionTestCase{
-		Command: command,
+		Command:             command,
+		SkipPromptAssertion: false,
 	}
 	if err := tc.Run(asserter, shell, logger, true); err != nil {
 		return err

--- a/internal/test_cases/command_reflection_test_case.go
+++ b/internal/test_cases/command_reflection_test_case.go
@@ -19,6 +19,9 @@ type CommandReflectionTestCase struct {
 
 	// SuccessMessage is the message to log in case of success
 	SuccessMessage string
+
+	// SkipPromptAssertion is a flag to skip the final prompt assertion
+	SkipPromptAssertion bool
 }
 
 func (t CommandReflectionTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger, skipSuccessMessage bool) error {
@@ -31,7 +34,14 @@ func (t CommandReflectionTestCase) Run(asserter *logged_shell_asserter.LoggedShe
 		ExpectedOutput: commandReflection,
 	})
 
-	if err := asserter.AssertWithoutPrompt(); err != nil {
+	var assertFuncToRun func() error
+	if t.SkipPromptAssertion {
+		assertFuncToRun = asserter.AssertWithoutPrompt
+	} else {
+		assertFuncToRun = asserter.AssertWithPrompt
+	}
+
+	if err := assertFuncToRun(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This update introduces a new boolean field, SkipPromptAssertion, to the CommandReflectionTestCase struct, allowing for conditional skipping of the final prompt assertion during test execution. The cd_test_case.go file has been updated to utilize this new flag, enhancing the flexibility of command reflection tests.