### PR TITLE
fix: adjust error logging in LoggedShellAsserter

### DIFF
--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -83,10 +83,9 @@ func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRow
 }
 
 func (a *LoggedShellAsserter) logAssertionError(err assertions.AssertionError) {
-	a.logRows(a.lastLoggedRowIndex+1, err.ErrorRowIndex)
-	l := a.Shell.GetLogger()
-	l.Errorf("%s", err.Message)
-	a.logRows(err.ErrorRowIndex, len(a.Shell.GetScreenState()))
+	a.logRows(a.lastLoggedRowIndex+1, err.ErrorRowIndex+1)
+	a.Shell.GetLogger().Errorf("%s", err.Message)
+	a.logRows(err.ErrorRowIndex+1, len(a.Shell.GetScreenState()))
 }
 
 func (a *LoggedShellAsserter) LogRemainingOutput() {

--- a/internal/test_helpers/fixtures/wrong_output
+++ b/internal/test_helpers/fixtures/wrong_output
@@ -3,9 +3,9 @@ Debug = true
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cz2[0m
 [33m[stage-2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ invalid_pear_command
+[33m[your-program] [0mCommand: invalid_pear_command
 [33m[stage-2] [0m[91mOutput does not match expected value.[0m
 [33m[stage-2] [0m[91m[32mExpected:[0m "invalid_pear_command: command not found"[0m
 [33m[stage-2] [0m[91m[31mReceived:[0m "Command: invalid_pear_command"[0m
-[33m[your-program] [0mCommand: invalid_pear_command
 [33m[stage-2] [0m[91mAssertion failed.[0m
 [33m[stage-2] [0m[91mTest failed[0m


### PR DESCRIPTION
Updated the logAssertionError method to correctly log assertion errors by incrementing the error row index. This change ensures that the logged rows accurately reflect the error context, improving the clarity of error reporting in the LoggedShellAsserter.