### PR TITLE
Add test-alpine CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,16 @@ jobs:
   test-alpine:
     runs-on: ubuntu-latest
     steps:
-      - uses: jirutka/setup-alpine@v1
+      - name: Setup Alpine
+        uses: jirutka/setup-alpine@v1
         with:
           branch: latest-stable
-          packages: make gcc musl-dev go~=1.22 python3 bash git
 
-      - run: cat /etc/alpine-release
-        shell: alpine.sh {0}
+      - name: Setup alpine dependencies
+        run: |
+          cat /etc/alpine-release
+          apk add git go make bash
+        shell: alpine.sh --root {0}
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,20 @@ jobs:
         with:
           version: "2023.1"
           install-go: false
+
+  test-alpine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jirutka/setup-alpine@v1
+        with:
+          branch: latest-stable
+          packages: make gcc musl-dev go~=1.22 python3 bash git
+
+      - run: cat /etc/alpine-release
+        shell: alpine.sh {0}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - run: make test_bash
+        shell: alpine.sh {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           branch: latest-stable
 
-      - name: Setup alpine dependencies
+      - name: Setup Alpine dependencies
         run: |
           cat /etc/alpine-release
           apk add git go make bash binutils-gold
@@ -48,7 +48,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: |
+      - name: Run tests against bash on alpine
+        run: |
           git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
+          # repo is owned by user and we intend to execute as root
           make test_bash
         shell: alpine.sh --root {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup alpine dependencies
         run: |
           cat /etc/alpine-release
-          apk add git go make bash
+          apk add git go make bash binutils-gold
         shell: alpine.sh --root {0}
 
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,5 @@ jobs:
         run: |
           git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
           # repo is owned by user and we intend to execute as root
-          make test_bash
+          make test
         shell: alpine.sh --root {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: make test_bash
+      - run: |
+          make test_bash
+          git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
         shell: alpine.sh --root {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
         uses: actions/checkout@v2
 
       - run: make test_bash
-        shell: alpine.sh {0}
+        shell: alpine.sh --root {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,6 @@ jobs:
         uses: actions/checkout@v2
 
       - run: |
-          make test_bash
           git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
+          make test_bash
         shell: alpine.sh --root {0}

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,57 @@ build:
 test:
 	TESTER_DIR=$(shell pwd) go test -count=1 -p 1 -v ./internal/...
 
+record_fixtures:
+	CODECRAFTERS_RECORD_FIXTURES=true make test
+
+update_tester_utils:
+	go get -u github.com/codecrafters-io/tester-utils
+
+copy_course_file:
+	gh api repos/codecrafters-io/build-your-own-shell/contents/course-definition.yml \
+		| jq -r .content \
+		| base64 -d \
+		> internal/test_helpers/course_definition.yml
+
+test_dash: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/dash \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"}, \
+		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
+		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
+		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
+		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"}, \
+		{\"slug\":\"ei0\",\"tester_log_prefix\":\"tester::#ei0\",\"title\":\"Stage #9: PWD\"}, \
+		{\"slug\":\"ra6\",\"tester_log_prefix\":\"tester::#ra6\",\"title\":\"Stage #10: CD-1\"}, \
+		{\"slug\":\"gq9\",\"tester_log_prefix\":\"tester::#gq9\",\"title\":\"Stage #11: CD-2\"}, \
+		{\"slug\":\"gp4\",\"tester_log_prefix\":\"tester::#gp4\",\"title\":\"Stage #12: CD-3\"} \
+	]" \
+	dist/main.out
+
+test_failure: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/failure \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
+	]" \
+	dist/main.out
+
+# Removes ALL zsh related config files across the system
+test_zsh_dangerously: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/zsh \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
+	]" \
+	dist/main.out
+
 test_base_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -41,72 +92,6 @@ test_nav_w_bash: build
 	]" \
 	dist/main.out
 
-test_dash: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/dash \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"}, \
-		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
-		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
-		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
-		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"}, \
-		{\"slug\":\"ei0\",\"tester_log_prefix\":\"tester::#ei0\",\"title\":\"Stage #9: PWD\"}, \
-		{\"slug\":\"ra6\",\"tester_log_prefix\":\"tester::#ra6\",\"title\":\"Stage #10: CD-1\"}, \
-		{\"slug\":\"gq9\",\"tester_log_prefix\":\"tester::#gq9\",\"title\":\"Stage #11: CD-2\"}, \
-		{\"slug\":\"gp4\",\"tester_log_prefix\":\"tester::#gp4\",\"title\":\"Stage #12: CD-3\"} \
-	]" \
-	dist/main.out
-
-test_ryan: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/ryan_shell \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
-		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
-		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
-		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"} \
-	]" \
-	dist/main.out
-
-test_all_success: test_bash test_dash
-
-test_failure: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/failure \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
-	]" \
-	dist/main.out
-
-# Removes ALL zsh related config files across the system
-test_zsh_dangerously: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/zsh \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
-	]" \
-	dist/main.out
-
-
-record_fixtures:
-	CODECRAFTERS_RECORD_FIXTURES=true make test
-
-update_tester_utils:
-	go get -u github.com/codecrafters-io/tester-utils
-
-copy_course_file:
-	gh api repos/codecrafters-io/build-your-own-shell/contents/course-definition.yml \
-		| jq -r .content \
-		| base64 -d \
-		> internal/test_helpers/course_definition.yml
-
 test_quoting_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -119,20 +104,6 @@ test_quoting_w_bash: build
 	]" \
 	dist/main.out
 
-test_quoting_minimal: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"ni6\",\"tester_log_prefix\":\"tester::#ni6\",\"title\":\"Stage #1: Quoting with single quotes\"}, \
-		{\"slug\":\"yt5\",\"tester_log_prefix\":\"tester::#yt5\",\"title\":\"Stage #3: Quoting with backslashes\"} \
-	]" \
-	dist/main.out
-
-test_bash:
-	make test_base_w_bash
-	make test_nav_w_bash
-	make test_quoting_w_bash
-
-
 test_redirection_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -142,3 +113,9 @@ test_redirection_w_bash: build
 		{\"slug\":\"un3\",\"tester_log_prefix\":\"tester::#un3\",\"title\":\"Stage #16: Append stderr\"} \
 	]" \
 	dist/main.out
+
+test_bash:
+	make test_base_w_bash
+	make test_nav_w_bash
+	make test_quoting_w_bash
+	make test_redirection_w_bash

--- a/Makefile
+++ b/Makefile
@@ -17,57 +17,6 @@ build:
 test:
 	TESTER_DIR=$(shell pwd) go test -count=1 -p 1 -v ./internal/...
 
-record_fixtures:
-	CODECRAFTERS_RECORD_FIXTURES=true make test
-
-update_tester_utils:
-	go get -u github.com/codecrafters-io/tester-utils
-
-copy_course_file:
-	gh api repos/codecrafters-io/build-your-own-shell/contents/course-definition.yml \
-		| jq -r .content \
-		| base64 -d \
-		> internal/test_helpers/course_definition.yml
-
-test_dash: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/dash \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"}, \
-		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
-		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
-		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
-		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"}, \
-		{\"slug\":\"ei0\",\"tester_log_prefix\":\"tester::#ei0\",\"title\":\"Stage #9: PWD\"}, \
-		{\"slug\":\"ra6\",\"tester_log_prefix\":\"tester::#ra6\",\"title\":\"Stage #10: CD-1\"}, \
-		{\"slug\":\"gq9\",\"tester_log_prefix\":\"tester::#gq9\",\"title\":\"Stage #11: CD-2\"}, \
-		{\"slug\":\"gp4\",\"tester_log_prefix\":\"tester::#gp4\",\"title\":\"Stage #12: CD-3\"} \
-	]" \
-	dist/main.out
-
-test_failure: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/failure \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
-	]" \
-	dist/main.out
-
-# Removes ALL zsh related config files across the system
-test_zsh_dangerously: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/zsh \
-	CODECRAFTERS_TEST_CASES_JSON="[ \
-		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
-		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
-		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
-		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
-	]" \
-	dist/main.out
-
 test_base_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -92,6 +41,72 @@ test_nav_w_bash: build
 	]" \
 	dist/main.out
 
+test_dash: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/dash \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"}, \
+		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
+		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
+		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
+		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"}, \
+		{\"slug\":\"ei0\",\"tester_log_prefix\":\"tester::#ei0\",\"title\":\"Stage #9: PWD\"}, \
+		{\"slug\":\"ra6\",\"tester_log_prefix\":\"tester::#ra6\",\"title\":\"Stage #10: CD-1\"}, \
+		{\"slug\":\"gq9\",\"tester_log_prefix\":\"tester::#gq9\",\"title\":\"Stage #11: CD-2\"}, \
+		{\"slug\":\"gp4\",\"tester_log_prefix\":\"tester::#gp4\",\"title\":\"Stage #12: CD-3\"} \
+	]" \
+	dist/main.out
+
+test_ryan: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/ryan_shell \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"iz3\",\"tester_log_prefix\":\"tester::#iz3\",\"title\":\"Stage #5: Echo\"}, \
+		{\"slug\":\"ez5\",\"tester_log_prefix\":\"tester::#ez5\",\"title\":\"Stage #6: Type built-in\"}, \
+		{\"slug\":\"mg5\",\"tester_log_prefix\":\"tester::#mg5\",\"title\":\"Stage #7: Type for executables\"}, \
+		{\"slug\":\"ip1\",\"tester_log_prefix\":\"tester::#ip1\",\"title\":\"Stage #8: Run a program\"} \
+	]" \
+	dist/main.out
+
+test_all_success: test_bash test_dash
+
+test_failure: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/failure \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
+	]" \
+	dist/main.out
+
+# Removes ALL zsh related config files across the system
+test_zsh_dangerously: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/zsh \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"oo8\",\"tester_log_prefix\":\"tester::#oo8\",\"title\":\"Stage #1: Init\"}, \
+		{\"slug\":\"cz2\",\"tester_log_prefix\":\"tester::#cz2\",\"title\":\"Stage #2: Invalid Command\"}, \
+		{\"slug\":\"ff0\",\"tester_log_prefix\":\"tester::#ff0\",\"title\":\"Stage #3: REPL\"}, \
+		{\"slug\":\"pn5\",\"tester_log_prefix\":\"tester::#pn5\",\"title\":\"Stage #4: Exit\"} \
+	]" \
+	dist/main.out
+
+
+record_fixtures:
+	CODECRAFTERS_RECORD_FIXTURES=true make test
+
+update_tester_utils:
+	go get -u github.com/codecrafters-io/tester-utils
+
+copy_course_file:
+	gh api repos/codecrafters-io/build-your-own-shell/contents/course-definition.yml \
+		| jq -r .content \
+		| base64 -d \
+		> internal/test_helpers/course_definition.yml
+
 test_quoting_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -104,6 +119,20 @@ test_quoting_w_bash: build
 	]" \
 	dist/main.out
 
+test_quoting_minimal: build
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"ni6\",\"tester_log_prefix\":\"tester::#ni6\",\"title\":\"Stage #1: Quoting with single quotes\"}, \
+		{\"slug\":\"yt5\",\"tester_log_prefix\":\"tester::#yt5\",\"title\":\"Stage #3: Quoting with backslashes\"} \
+	]" \
+	dist/main.out
+
+test_bash:
+	make test_base_w_bash
+	make test_nav_w_bash
+	make test_quoting_w_bash
+
+
 test_redirection_w_bash: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/bash \
 	CODECRAFTERS_TEST_CASES_JSON="[ \
@@ -113,9 +142,3 @@ test_redirection_w_bash: build
 		{\"slug\":\"un3\",\"tester_log_prefix\":\"tester::#un3\",\"title\":\"Stage #16: Append stderr\"} \
 	]" \
 	dist/main.out
-
-test_bash:
-	make test_base_w_bash
-	make test_nav_w_bash
-	make test_quoting_w_bash
-	make test_redirection_w_bash


### PR DESCRIPTION
This pull request includes a refactoring of the Makefile to streamline it by removing obsolete test targets and adding new ones. Additionally, a new CI job called test-alpine has been added, which runs on the latest stable version of Alpine Linux and includes steps to install necessary packages and run tests using the Alpine environment.