### PR TITLE
Refactor MultiLineAssertions to use SingleLineAssertions internally

### DIFF
--- a/internal/assertions/multi_line_assertion.go
+++ b/internal/assertions/multi_line_assertion.go
@@ -3,54 +3,59 @@ package assertions
 import (
 	"fmt"
 	"regexp"
-	"strings"
-
-	"github.com/codecrafters-io/shell-tester/internal/utils"
-	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 )
 
 // MultiLineAssertion asserts that multiple lines of output matches against a given array of strings
 // Or a multi-line regex pattern(s)
 type MultiLineAssertion struct {
-	// ExpectedOutput is the array of expected output strings to match against
-	ExpectedOutput []string
-
-	// FallbackPatterns is a list of regex patterns to match against. This is useful to handle shell-specific variable behaviour
-	FallbackPatterns []*regexp.Regexp
+	SingleLineAssertions []SingleLineAssertion
 }
 
-func (a MultiLineAssertion) Inspect() string {
-	return fmt.Sprintf("MultiLineAssertion (%q)", a.ExpectedOutput)
+func NewMultiLineAssertion(expectedOutput []string) MultiLineAssertion {
+	// No way to add fallbackPatterns through this constructor
+	singleLineAssertions := []SingleLineAssertion{}
+	for _, expectedLine := range expectedOutput {
+		singleLineAssertions = append(singleLineAssertions, SingleLineAssertion{
+			ExpectedOutput: expectedLine,
+		})
+	}
+
+	fmt.Println(singleLineAssertions)
+
+	return MultiLineAssertion{
+		SingleLineAssertions: singleLineAssertions,
+	}
 }
 
-func (a MultiLineAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
-	if len(a.ExpectedOutput) == 0 {
-		panic("CodeCrafters Internal Error: ExpectedOutput must be provided")
+func NewEmptyMultiLineAssertion() MultiLineAssertion {
+	return MultiLineAssertion{
+		SingleLineAssertions: []SingleLineAssertion{},
 	}
+}
 
-	totalRows := len(a.ExpectedOutput)
-	rawRows := screenState[startRowIndex : startRowIndex+totalRows]
-	cleanedRows := []string{}
-	for _, rawRow := range rawRows {
-		cleanedRows = append(cleanedRows, virtual_terminal.BuildCleanedRow(rawRow))
-	}
-	cleanedRowsString := strings.Join(cleanedRows, "\n")
-	expectedOutputString := strings.Join(a.ExpectedOutput, "\n")
+// AddSingleLineAssertion is the recommended way to add single line assertions
+// When they contain fallbackPatterns
+func (a *MultiLineAssertion) AddSingleLineAssertion(expectedOutput string, fallbackPatterns []*regexp.Regexp) *MultiLineAssertion {
+	a.SingleLineAssertions = append(a.SingleLineAssertions, SingleLineAssertion{
+		ExpectedOutput:   expectedOutput,
+		FallbackPatterns: fallbackPatterns,
+	})
+	return a
+}
 
-	for _, pattern := range a.FallbackPatterns {
-		if pattern.Match([]byte(cleanedRowsString)) {
-			return len(a.ExpectedOutput), nil
+func (a *MultiLineAssertion) Inspect() string {
+	return fmt.Sprintf("MultiLineAssertion (%q)", a.SingleLineAssertions)
+}
+
+func (a *MultiLineAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+	totalProcessedRowCount := 0
+
+	for _, singleLineAssertion := range a.SingleLineAssertions {
+		processedRowCount, err = singleLineAssertion.Run(screenState, startRowIndex+totalProcessedRowCount)
+		if err != nil {
+			return totalProcessedRowCount, err
 		}
+		totalProcessedRowCount += processedRowCount
 	}
-
-	if cleanedRowsString != expectedOutputString {
-		detailedErrorMessage := utils.BuildColoredErrorMessage(expectedOutputString, cleanedRowsString)
-		return 0, &AssertionError{
-			StartRowIndex: startRowIndex,
-			ErrorRowIndex: startRowIndex,
-			Message:       "Output does not match expected value.\n" + detailedErrorMessage,
-		}
-	} else {
-		return len(a.ExpectedOutput), nil
-	}
+	return totalProcessedRowCount, nil
 }

--- a/internal/assertions/multi_line_assertion.go
+++ b/internal/assertions/multi_line_assertion.go
@@ -20,8 +20,6 @@ func NewMultiLineAssertion(expectedOutput []string) MultiLineAssertion {
 		})
 	}
 
-	fmt.Println(singleLineAssertions)
-
 	return MultiLineAssertion{
 		SingleLineAssertions: singleLineAssertions,
 	}

--- a/internal/stage_r1.go
+++ b/internal/stage_r1.go
@@ -66,8 +66,6 @@ func testR1(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	fmt.Println(randomWords)
-
 	multiLineTestCase := test_cases.CommandWithMultilineResponseTestCase{
 		Command:            command2,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(randomWords),

--- a/internal/stage_r1.go
+++ b/internal/stage_r1.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"slices"
 
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -65,11 +66,12 @@ func testR1(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	fmt.Println(randomWords)
+
 	multiLineTestCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:          command2,
-		ExpectedOutput:   randomWords,
-		FallbackPatterns: nil,
-		SuccessMessage:   "✓ Received redirected file content",
+		Command:            command2,
+		MultiLineAssertion: assertions.NewMultiLineAssertion(randomWords),
+		SuccessMessage:     "✓ Received redirected file content",
 	}
 	if err := multiLineTestCase.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stage_r3.go
+++ b/internal/stage_r3.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"slices"
 
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -64,10 +65,9 @@ func testR3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	responseTestCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:          command2,
-		ExpectedOutput:   randomWords,
-		FallbackPatterns: nil,
-		SuccessMessage:   "✓ Received redirected file content",
+		Command:            command2,
+		MultiLineAssertion: assertions.NewMultiLineAssertion(randomWords),
+		SuccessMessage:     "✓ Received redirected file content",
 	}
 
 	if err := responseTestCase.Run(asserter, shell, logger); err != nil {
@@ -98,10 +98,9 @@ func testR3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	responseTestCase = test_cases.CommandWithMultilineResponseTestCase{
-		Command:          command6,
-		ExpectedOutput:   []string{message1, message2},
-		FallbackPatterns: nil,
-		SuccessMessage:   "✓ Received redirected file content",
+		Command:            command6,
+		MultiLineAssertion: assertions.NewMultiLineAssertion([]string{message1, message2}),
+		SuccessMessage:     "✓ Received redirected file content",
 	}
 	if err := responseTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -129,10 +128,9 @@ func testR3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	responseTestCase = test_cases.CommandWithMultilineResponseTestCase{
-		Command:          command9,
-		ExpectedOutput:   append([]string{"List of files:"}, randomWords...),
-		FallbackPatterns: nil,
-		SuccessMessage:   "✓ Received redirected file content",
+		Command:            command9,
+		MultiLineAssertion: assertions.NewMultiLineAssertion(append([]string{"List of files:"}, randomWords...)),
+		SuccessMessage:     "✓ Received redirected file content",
 	}
 	if err := responseTestCase.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stage_r4.go
+++ b/internal/stage_r4.go
@@ -131,17 +131,20 @@ func testR4(stageHarness *test_case_harness.TestCaseHarness) error {
 		"cat: nonexistent: No such file or directory",
 		"ls: nonexistent: No such file or directory",
 	}
+
 	linuxLSErrorMessage := "ls: cannot access 'nonexistent': No such file or directory"
+	linuxLSErrorMessageRegex := []*regexp.Regexp{regexp.MustCompile(fmt.Sprintf("^%s$", linuxLSErrorMessage))}
 	alpineCatErrorMessage := "cat: can't open 'nonexistent': No such file or directory"
-	essorMessagesInFileRegex := []*regexp.Regexp{
-		regexp.MustCompile(fmt.Sprintf("^%s\n%s$", errorMessagesInFile[0], linuxLSErrorMessage)),
-		regexp.MustCompile(fmt.Sprintf("^%s\n%s$", alpineCatErrorMessage, errorMessagesInFile[1])),
-	}
+	alpineCatErrorMessageRegex := []*regexp.Regexp{regexp.MustCompile(fmt.Sprintf("^%s$", alpineCatErrorMessage))}
+
+	multiLineAssertion := assertions.NewEmptyMultiLineAssertion()
+	multiLineAssertion.AddSingleLineAssertion(errorMessagesInFile[0], alpineCatErrorMessageRegex)
+	multiLineAssertion.AddSingleLineAssertion(errorMessagesInFile[1], linuxLSErrorMessageRegex)
+
 	multiLineResponseTestCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:          command7,
-		ExpectedOutput:   errorMessagesInFile,
-		FallbackPatterns: essorMessagesInFileRegex,
-		SuccessMessage:   "✓ Received redirected file content",
+		Command:            command7,
+		MultiLineAssertion: multiLineAssertion,
+		SuccessMessage:     "✓ Received redirected file content",
 	}
 	if err := multiLineResponseTestCase.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/test_cases/command_reflection_test_case.go
+++ b/internal/test_cases/command_reflection_test_case.go
@@ -46,7 +46,7 @@ func (t CommandReflectionTestCase) Run(asserter *logged_shell_asserter.LoggedShe
 	}
 
 	if !skipSuccessMessage {
-		logger.Successf(t.SuccessMessage)
+		logger.Successf("%s", t.SuccessMessage)
 	}
 	return nil
 }

--- a/internal/test_cases/command_response_test_case.go
+++ b/internal/test_cases/command_response_test_case.go
@@ -48,6 +48,6 @@ func (t CommandResponseTestCase) Run(asserter *logged_shell_asserter.LoggedShell
 		return err
 	}
 
-	logger.Successf(t.SuccessMessage)
+	logger.Successf("%s", t.SuccessMessage)
 	return nil
 }

--- a/internal/test_cases/command_with_multiline_response_test_case.go
+++ b/internal/test_cases/command_with_multiline_response_test_case.go
@@ -2,7 +2,6 @@ package test_cases
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -14,11 +13,8 @@ type CommandWithMultilineResponseTestCase struct {
 	// Command is the command to send to the shell
 	Command string
 
-	// ExpectedOutput is the expected output string to match against
-	ExpectedOutput []string
-
-	// FallbackPatterns is a list of regex patterns to match against
-	FallbackPatterns []*regexp.Regexp
+	// MultiLineAssertion is the assertion to run
+	MultiLineAssertion assertions.MultiLineAssertion
 
 	// SuccessMessage is the message to log in case of success
 	SuccessMessage string
@@ -34,10 +30,7 @@ func (t CommandWithMultilineResponseTestCase) Run(asserter *logged_shell_asserte
 		ExpectedOutput: commandReflection,
 	})
 
-	asserter.AddAssertion(assertions.MultiLineAssertion{
-		ExpectedOutput:   t.ExpectedOutput,
-		FallbackPatterns: t.FallbackPatterns,
-	})
+	asserter.AddAssertion(&t.MultiLineAssertion)
 
 	if err := asserter.AssertWithPrompt(); err != nil {
 		return err

--- a/internal/test_cases/command_with_multiline_response_test_case.go
+++ b/internal/test_cases/command_with_multiline_response_test_case.go
@@ -43,6 +43,6 @@ func (t CommandWithMultilineResponseTestCase) Run(asserter *logged_shell_asserte
 		return err
 	}
 
-	logger.Successf(t.SuccessMessage)
+	logger.Successf("%s", t.SuccessMessage)
 	return nil
 }


### PR DESCRIPTION
This pull request includes significant refactoring and enhancements to the multi-line assertion functionality within the codebase. The changes mainly focus on replacing the old method of handling multi-line assertions with a more structured and flexible approach. Additionally, some minor improvements and cleanups are included.

### Refactoring and Enhancements:

* [`internal/assertions/multi_line_assertion.go`](diffhunk://#diff-bc7da16d48bd4bc8aa3f4b4b78135ad951410e145ed953768f7f3416b62dcadaL6-R58): Replaced the `ExpectedOutput` and `FallbackPatterns` fields with a `SingleLineAssertions` slice. Added methods to construct and manipulate multi-line assertions, including `NewMultiLineAssertion`, `NewEmptyMultiLineAssertion`, `AddSingleLineAssertion`, and updated `Run` method to handle the new structure.

* [`internal/stage_r1.go`](diffhunk://#diff-fac57a6ce722e03832e80ffe2c85d6398589296ae41c853465db8aeb1be26f87R10): Updated the `testR1` function to use the new `MultiLineAssertion` constructor for multi-line test cases. [[1]](diffhunk://#diff-fac57a6ce722e03832e80ffe2c85d6398589296ae41c853465db8aeb1be26f87R10) [[2]](diffhunk://#diff-fac57a6ce722e03832e80ffe2c85d6398589296ae41c853465db8aeb1be26f87L70-R71)

* [`internal/stage_r3.go`](diffhunk://#diff-379a812b5679bf99739e4ad99e2c817b3de2594d055e6a472d08e804825f5534R8): Updated the `testR3` function to use the new `MultiLineAssertion` constructor for multi-line test cases. [[1]](diffhunk://#diff-379a812b5679bf99739e4ad99e2c817b3de2594d055e6a472d08e804825f5534R8) [[2]](diffhunk://#diff-379a812b5679bf99739e4ad99e2c817b3de2594d055e6a472d08e804825f5534L68-R69) [[3]](diffhunk://#diff-379a812b5679bf99739e4ad99e2c817b3de2594d055e6a472d08e804825f5534L102-R102) [[4]](diffhunk://#diff-379a812b5679bf99739e4ad99e2c817b3de2594d055e6a472d08e804825f5534L133-R132)

* [`internal/stage_r4.go`](diffhunk://#diff-bb33e3606d876480647ee0c9a9cc1feff6a390681f5e59aff56a9d523dc7220fR134-R146): Enhanced the `testR4` function to use the new `MultiLineAssertion` structure, including handling regex patterns for error messages.

### Minor Improvements:

* `internal/test_cases/command_reflection_test_case.go` and `internal/test_cases/command_response_test_case.go`: Modified the `Run` method to use formatted strings for success messages. [[1]](diffhunk://#diff-80aece1a9855022b36d978d6227d3916c7bc7aad6ee40a9e0129f79c03510e19L49-R49) [[2]](diffhunk://#diff-8eb19feb270feb3778ad353a763f6776eef25cde9dbd9ae41ab223c98b2db475L51-R51)

* [`internal/test_cases/command_with_multiline_response_test_case.go`](diffhunk://#diff-9cfc441ddf3cb7747c9986d22a972eef084496594a4f14ad41858257b1c2e776L5): Updated the `CommandWithMultilineResponseTestCase` struct to use the new `MultiLineAssertion` field and modified the `Run` method accordingly. [[1]](diffhunk://#diff-9cfc441ddf3cb7747c9986d22a972eef084496594a4f14ad41858257b1c2e776L5) [[2]](diffhunk://#diff-9cfc441ddf3cb7747c9986d22a972eef084496594a4f14ad41858257b1c2e776L17-R17) [[3]](diffhunk://#diff-9cfc441ddf3cb7747c9986d22a972eef084496594a4f14ad41858257b1c2e776L37-R39)