### PR TITLE
Refactor shell assertion methods and timeout handling

### DIFF
--- a/internal/condition_reader/condition_reader.go
+++ b/internal/condition_reader/condition_reader.go
@@ -22,15 +22,6 @@ func NewConditionReader(reader io.Reader) ConditionReader {
 	}
 }
 
-func (t *ConditionReader) ReadUntilCondition(condition func() bool, useLongerTimeout bool) error {
-	timeout := 2000 * time.Millisecond
-	if useLongerTimeout {
-		timeout = 5000 * time.Millisecond
-	}
-
-	return t.ReadUntilConditionOrTimeout(condition, timeout)
-}
-
 func (t *ConditionReader) ReadUntilConditionOrTimeout(condition func() bool, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 

--- a/internal/condition_reader/condition_reader.go
+++ b/internal/condition_reader/condition_reader.go
@@ -48,18 +48,3 @@ func (t *ConditionReader) ReadUntilConditionOrTimeout(condition func() bool, tim
 
 	return ErrConditionNotMet
 }
-
-func (t *ConditionReader) ReadUntilTimeout(timeout time.Duration) error {
-	alwaysFalseCondition := func() bool {
-		return false
-	}
-
-	err := t.ReadUntilConditionOrTimeout(alwaysFalseCondition, timeout)
-
-	// We expect that the condition is never met, so let's return nil as the error
-	if errors.Is(err, ErrConditionNotMet) {
-		return nil
-	}
-
-	return err
-}

--- a/internal/condition_reader/condition_reader.go
+++ b/internal/condition_reader/condition_reader.go
@@ -22,8 +22,13 @@ func NewConditionReader(reader io.Reader) ConditionReader {
 	}
 }
 
-func (t *ConditionReader) ReadUntilCondition(condition func() bool) error {
-	return t.ReadUntilConditionOrTimeout(condition, 2000*time.Millisecond)
+func (t *ConditionReader) ReadUntilCondition(condition func() bool, useLongerTimeout bool) error {
+	timeout := 2000 * time.Millisecond
+	if useLongerTimeout {
+		timeout = 5000 * time.Millisecond
+	}
+
+	return t.ReadUntilConditionOrTimeout(condition, timeout)
 }
 
 func (t *ConditionReader) ReadUntilConditionOrTimeout(condition func() bool, timeout time.Duration) error {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -10,7 +10,8 @@ import (
 	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 )
 
-// We use a longer read timeout for the first prompt read
+// INITIAL_READ_TIMEOUT is used for the first prompt read, where we want
+// to be more lenient, and allow user's shells to start up properly
 const INITIAL_READ_TIMEOUT = 5000 * time.Millisecond
 const SUBSEQUENT_READ_TIMEOUT = 2000 * time.Millisecond
 

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -2,6 +2,7 @@ package logged_shell_asserter
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertion_collection"
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
@@ -43,18 +44,14 @@ func (a *LoggedShellAsserter) AddAssertion(assertion assertions.Assertion) {
 }
 
 func (a *LoggedShellAsserter) AssertWithPrompt() error {
-	return a.assert(false, false)
+	return a.assert(false)
 }
 
 func (a *LoggedShellAsserter) AssertWithoutPrompt() error {
-	return a.assert(true, false)
+	return a.assert(true)
 }
 
-func (a *LoggedShellAsserter) AssertWithPromptAndLongerTimeout() error {
-	return a.assert(false, true)
-}
-
-func (a *LoggedShellAsserter) assert(withoutPrompt bool, useLongerTimeout bool) error {
+func (a *LoggedShellAsserter) assert(withoutPrompt bool) error {
 	var assertFn func() *assertions.AssertionError
 
 	if withoutPrompt {
@@ -71,7 +68,7 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, useLongerTimeout bool) 
 		return assertFn() == nil
 	}
 
-	if readErr := a.Shell.ReadUntil(conditionFn, useLongerTimeout); readErr != nil {
+	if readErr := a.Shell.ReadUntilConditionOrTimeout(conditionFn, 2000*time.Millisecond); readErr != nil {
 		if assertionErr := assertFn(); assertionErr != nil {
 			a.logAssertionError(*assertionErr)
 			return fmt.Errorf("Assertion failed.")

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -10,8 +10,9 @@ import (
 	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 )
 
-const DEFAULT_READ_TIMEOUT = 2000 * time.Millisecond
-const LONGER_READ_TIMEOUT = 5000 * time.Millisecond
+// We use a longer read timeout for the first prompt read
+const INITIAL_READ_TIMEOUT = 5000 * time.Millisecond
+const SUBSEQUENT_READ_TIMEOUT = 2000 * time.Millisecond
 
 type LoggedShellAsserter struct {
 	Shell               *shell_executable.ShellExecutable
@@ -47,15 +48,15 @@ func (a *LoggedShellAsserter) AddAssertion(assertion assertions.Assertion) {
 }
 
 func (a *LoggedShellAsserter) AssertWithPrompt() error {
-	return a.assert(false, DEFAULT_READ_TIMEOUT)
+	return a.assert(false, SUBSEQUENT_READ_TIMEOUT)
 }
 
 func (a *LoggedShellAsserter) AssertWithoutPrompt() error {
-	return a.assert(true, DEFAULT_READ_TIMEOUT)
+	return a.assert(true, SUBSEQUENT_READ_TIMEOUT)
 }
 
 func (a *LoggedShellAsserter) AssertWithPromptAndLongerTimeout() error {
-	return a.assert(false, LONGER_READ_TIMEOUT)
+	return a.assert(false, INITIAL_READ_TIMEOUT)
 }
 
 func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Duration) error {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -40,7 +40,7 @@ func (a *LoggedShellAsserter) StartShellAndAssertPrompt() error {
 		return err
 	}
 
-	return a.AssertWithPrompt()
+	return a.AssertWithPromptAndLongerTimeout()
 }
 
 func (a *LoggedShellAsserter) AddAssertion(assertion assertions.Assertion) {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -43,14 +43,18 @@ func (a *LoggedShellAsserter) AddAssertion(assertion assertions.Assertion) {
 }
 
 func (a *LoggedShellAsserter) AssertWithPrompt() error {
-	return a.assert(false)
+	return a.assert(false, false)
 }
 
 func (a *LoggedShellAsserter) AssertWithoutPrompt() error {
-	return a.assert(true)
+	return a.assert(true, false)
 }
 
-func (a *LoggedShellAsserter) assert(withoutPrompt bool) error {
+func (a *LoggedShellAsserter) AssertWithPromptAndLongerTimeout() error {
+	return a.assert(false, true)
+}
+
+func (a *LoggedShellAsserter) assert(withoutPrompt bool, useLongerTimeout bool) error {
 	var assertFn func() *assertions.AssertionError
 
 	if withoutPrompt {
@@ -67,7 +71,7 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool) error {
 		return assertFn() == nil
 	}
 
-	if readErr := a.Shell.ReadUntil(conditionFn); readErr != nil {
+	if readErr := a.Shell.ReadUntil(conditionFn, useLongerTimeout); readErr != nil {
 		if assertionErr := assertFn(); assertionErr != nil {
 			a.logAssertionError(*assertionErr)
 			return fmt.Errorf("Assertion failed.")

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -97,15 +97,6 @@ func (b *ShellExecutable) ReadUntilConditionOrTimeout(condition func() bool, tim
 	return nil
 }
 
-func (b *ShellExecutable) ReadUntilTimeout(timeout time.Duration) error {
-	err := b.ptyReader.ReadUntilTimeout(timeout)
-	if err != nil {
-		return wrapReaderError(err)
-	}
-
-	return nil
-}
-
 func (b *ShellExecutable) SendCommand(command string) error {
 	// b.logger.Infof("> %s", command)
 

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -88,8 +88,8 @@ func (b *ShellExecutable) LogOutput(output []byte) {
 	b.programLogger.Plainln(string(output))
 }
 
-func (b *ShellExecutable) ReadUntil(condition func() bool) error {
-	err := b.ptyReader.ReadUntilCondition(condition)
+func (b *ShellExecutable) ReadUntil(condition func() bool, useLongerTimeout bool) error {
+	err := b.ptyReader.ReadUntilCondition(condition, useLongerTimeout)
 	if err != nil {
 		return wrapReaderError(err)
 	}

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -88,8 +88,8 @@ func (b *ShellExecutable) LogOutput(output []byte) {
 	b.programLogger.Plainln(string(output))
 }
 
-func (b *ShellExecutable) ReadUntil(condition func() bool, useLongerTimeout bool) error {
-	err := b.ptyReader.ReadUntilCondition(condition, useLongerTimeout)
+func (b *ShellExecutable) ReadUntilConditionOrTimeout(condition func() bool, timeout time.Duration) error {
+	err := b.ptyReader.ReadUntilConditionOrTimeout(condition, timeout)
 	if err != nil {
 		return wrapReaderError(err)
 	}

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -40,7 +40,7 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	assertFn := func() error {
 		return asserter.AssertionCollection.RunWithPromptAssertion(shell.GetScreenState())
 	}
-	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), DEFAULT_READ_TIMEOUT)
+	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), logged_shell_asserter.DEFAULT_READ_TIMEOUT)
 	output := virtual_terminal.BuildCleanedRow(shell.GetScreenState()[asserter.GetLastLoggedRowIndex()+1])
 
 	// We're expecting EOF since the program should've terminated

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -40,7 +40,7 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	assertFn := func() error {
 		return asserter.AssertionCollection.RunWithPromptAssertion(shell.GetScreenState())
 	}
-	readErr := shell.ReadUntil(utils.AsBool(assertFn), false)
+	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), DEFAULT_READ_TIMEOUT)
 	output := virtual_terminal.BuildCleanedRow(shell.GetScreenState()[asserter.GetLastLoggedRowIndex()+1])
 
 	// We're expecting EOF since the program should've terminated

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -40,7 +40,7 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	assertFn := func() error {
 		return asserter.AssertionCollection.RunWithPromptAssertion(shell.GetScreenState())
 	}
-	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), logged_shell_asserter.DEFAULT_READ_TIMEOUT)
+	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), logged_shell_asserter.SUBSEQUENT_READ_TIMEOUT)
 	output := virtual_terminal.BuildCleanedRow(shell.GetScreenState()[asserter.GetLastLoggedRowIndex()+1])
 
 	// We're expecting EOF since the program should've terminated

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -40,7 +40,7 @@ func testExit(stageHarness *test_case_harness.TestCaseHarness) error {
 	assertFn := func() error {
 		return asserter.AssertionCollection.RunWithPromptAssertion(shell.GetScreenState())
 	}
-	readErr := shell.ReadUntil(utils.AsBool(assertFn))
+	readErr := shell.ReadUntil(utils.AsBool(assertFn), false)
 	output := virtual_terminal.BuildCleanedRow(shell.GetScreenState()[asserter.GetLastLoggedRowIndex()+1])
 
 	// We're expecting EOF since the program should've terminated

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -13,6 +14,9 @@ import (
 
 var SMALL_WORDS = []string{"foo", "bar", "baz", "qux", "quz"}
 var LARGE_WORDS = []string{"hello", "world", "test", "example", "shell", "script"}
+
+const DEFAULT_READ_TIMEOUT = 2000 * time.Millisecond
+const LONGER_READ_TIMEOUT = 5000 * time.Millisecond
 
 // getRandomDirectory creates a random directory in /tmp, creates the directories and returns the full path
 // directory is of the form `/tmp/<random-word>/<random-word>/<random-word>`

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -14,9 +13,6 @@ import (
 
 var SMALL_WORDS = []string{"foo", "bar", "baz", "qux", "quz"}
 var LARGE_WORDS = []string{"hello", "world", "test", "example", "shell", "script"}
-
-const DEFAULT_READ_TIMEOUT = 2000 * time.Millisecond
-const LONGER_READ_TIMEOUT = 5000 * time.Millisecond
 
 // getRandomDirectory creates a random directory in /tmp, creates the directories and returns the full path
 // directory is of the form `/tmp/<random-word>/<random-word>/<random-word>`


### PR DESCRIPTION
This pull request refactors the shell assertion methods and timeout handling. The `AssertWithPrompt` and `AssertWithoutPrompt` methods have been updated to support configurable timeout. Additionally, a new method `AssertWithPromptAndLongerTimeout` has been introduced for assertions requiring extended timeout. The `ReadUntil` method in `ShellExecutable` now accepts a timeout parameter, ensuring consistent timeout handling across shell assertion and reading operations.