### PR TITLE
Refactor ShellExecutable and ConditionReader to support configurable read timeout

### DIFF
--- a/internal/condition_reader/condition_reader.go
+++ b/internal/condition_reader/condition_reader.go
@@ -14,16 +14,18 @@ var ErrConditionNotMet = errors.New("condition not met")
 // ConditionReader wraps an io.Reader and provides methods to read until a condition is met
 type ConditionReader struct {
 	asyncReader *async_reader.AsyncReader
+	readTimeout time.Duration
 }
 
-func NewConditionReader(reader io.Reader) ConditionReader {
+func NewConditionReader(reader io.Reader, readTimeout time.Duration) ConditionReader {
 	return ConditionReader{
 		asyncReader: async_reader.New(bufio.NewReader(reader)),
+		readTimeout: readTimeout,
 	}
 }
 
 func (t *ConditionReader) ReadUntilCondition(condition func() bool) error {
-	return t.ReadUntilConditionOrTimeout(condition, 2000*time.Millisecond)
+	return t.ReadUntilConditionOrTimeout(condition, t.readTimeout)
 }
 
 func (t *ConditionReader) ReadUntilConditionOrTimeout(condition func() bool, timeout time.Duration) error {

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -61,15 +61,16 @@ func (b *ShellExecutable) Setenv(key, value string) {
 // Start starts the shell executable and returns an error if it fails
 // If args[0] is "setLongerReadTimeout", the read timeout will be set to 5000ms
 func (b *ShellExecutable) Start(args ...string) error {
-	b.stageLogger.Infof(b.getInitialLogLine(args...))
-
 	b.Setenv("PS1", utils.PROMPT)
 	// b.Setenv("TERM", "dumb") // test_all_success works without this too, do we need it?
+
 	readTimeout := 2000 * time.Millisecond
 	if len(args) > 0 && args[0] == "setLongerReadTimeout" {
 		readTimeout = 5000 * time.Millisecond
 		args = args[1:]
 	}
+
+	b.stageLogger.Infof(b.getInitialLogLine(args...))
 
 	cmd := exec.Command(b.executable.Path, args...)
 	cmd.Env = b.env.Sorted()

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -81,6 +81,7 @@ func (b *ShellExecutable) Start(args ...string) error {
 	readTimeout := 2000 * time.Millisecond
 	if len(args) > 0 && args[0] == "setLongerReadTimeout" {
 		readTimeout = 5000 * time.Millisecond
+		args = args[1:]
 	}
 	b.ptyReader = condition_reader.NewConditionReader(io.TeeReader(b.pty, b.vt), readTimeout)
 

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -65,6 +65,11 @@ func (b *ShellExecutable) Start(args ...string) error {
 
 	b.Setenv("PS1", utils.PROMPT)
 	// b.Setenv("TERM", "dumb") // test_all_success works without this too, do we need it?
+	readTimeout := 2000 * time.Millisecond
+	if len(args) > 0 && args[0] == "setLongerReadTimeout" {
+		readTimeout = 5000 * time.Millisecond
+		args = args[1:]
+	}
 
 	cmd := exec.Command(b.executable.Path, args...)
 	cmd.Env = b.env.Sorted()
@@ -77,12 +82,6 @@ func (b *ShellExecutable) Start(args ...string) error {
 	b.cmd = cmd
 	b.pty = pty
 	b.vt = virtual_terminal.NewStandardVT()
-
-	readTimeout := 2000 * time.Millisecond
-	if len(args) > 0 && args[0] == "setLongerReadTimeout" {
-		readTimeout = 5000 * time.Millisecond
-		args = args[1:]
-	}
 	b.ptyReader = condition_reader.NewConditionReader(io.TeeReader(b.pty, b.vt), readTimeout)
 
 	return nil

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -58,6 +58,8 @@ func (b *ShellExecutable) Setenv(key, value string) {
 	b.env.Set(key, value)
 }
 
+// Start starts the shell executable and returns an error if it fails
+// If args[0] is "setLongerReadTimeout", the read timeout will be set to 5000ms
 func (b *ShellExecutable) Start(args ...string) error {
 	b.stageLogger.Infof(b.getInitialLogLine(args...))
 
@@ -75,7 +77,12 @@ func (b *ShellExecutable) Start(args ...string) error {
 	b.cmd = cmd
 	b.pty = pty
 	b.vt = virtual_terminal.NewStandardVT()
-	b.ptyReader = condition_reader.NewConditionReader(io.TeeReader(b.pty, b.vt))
+
+	readTimeout := 2000 * time.Millisecond
+	if len(args) > 0 && args[0] == "setLongerReadTimeout" {
+		readTimeout = 5000 * time.Millisecond
+	}
+	b.ptyReader = condition_reader.NewConditionReader(io.TeeReader(b.pty, b.vt), readTimeout)
 
 	return nil
 }

--- a/internal/stage1.go
+++ b/internal/stage1.go
@@ -23,7 +23,12 @@ func testPrompt(stageHarness *test_case_harness.TestCaseHarness) error {
 	// ensures that we never accept starter code that wouldn't work in those stages.
 	shell.Setenv("HOME", randomDir)
 
-	if err := startShellAndAssertPrompt(asserter, shell); err != nil {
+	// Sets a longer read timeout for the shell: 5000ms instead of 2000ms
+	if err := shell.Start("setLongerReadTimeout"); err != nil {
+		return err
+	}
+
+	if err := asserter.AssertWithPrompt(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This pull request refactors the `ShellExecutable` and `ConditionReader` classes to support a configurable read timeout. The `ShellExecutable.Start` method now accepts an optional argument, "setLongerReadTimeout", which sets the read timeout to 5000ms instead of the default 2000ms. The `ConditionReader` class has been updated to accept a `readTimeout` parameter, allowing for improved flexibility in reading operations. Additionally, the `testPrompt` function has been modified to set a longer read timeout of 5000ms for the shell, ensuring proper assertion with the new timeout configuration.