### PR TITLE
Add workaround for .NET ReadLine() command duplication issue

### DIFF
--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -41,7 +41,15 @@ func (a *LoggedShellAsserter) StartShellAndAssertPrompt() error {
 		return err
 	}
 
-	return a.AssertWithPromptAndLongerTimeout()
+	err := a.AssertWithPromptAndLongerTimeout()
+	if err != nil {
+		return err
+	}
+
+	// .NET ReadLine() method seems to have a bug where it prints the command twice
+	// in certain cases. This sleep is a workaround for that. Refer to: CC-1576
+	time.Sleep(10 * time.Millisecond)
+	return nil
 }
 
 func (a *LoggedShellAsserter) AddAssertion(assertion assertions.Assertion) {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -41,8 +41,7 @@ func (a *LoggedShellAsserter) StartShellAndAssertPrompt() error {
 		return err
 	}
 
-	err := a.AssertWithPromptAndLongerTimeout()
-	if err != nil {
+	if err := a.AssertWithPromptAndLongerTimeout(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Implement a workaround to address the command duplication issue encountered with the .NET ReadLine() method by introducing a brief sleep after asserting the prompt. Refer to CC-1576 for details.