### PR TITLE
Update tests & fallbackPatterns to pass against `ash`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Run tests against bash on alpine
+      - name: Run tests against ash
         run: |
           git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
           # repo is owned by user and we intend to execute as root
+          make test_ash
+        shell: alpine.sh --root {0}
+
+      - name: Run tests against bash on alpine
+        run: |
           make test
         shell: alpine.sh --root {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Alpine dependencies
         run: |
           cat /etc/alpine-release
-          apk add git go make bash binutils-gold
+          apk add git go make bash binutils-gold python3
         shell: alpine.sh --root {0}
 
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,27 @@ jobs:
         with:
           version: "2023.1"
           install-go: false
+
+  test-alpine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Alpine
+        uses: jirutka/setup-alpine@v1
+        with:
+          branch: latest-stable
+
+      - name: Setup Alpine dependencies
+        run: |
+          cat /etc/alpine-release
+          apk add git go make bash binutils-gold
+        shell: alpine.sh --root {0}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run tests against bash on alpine
+        run: |
+          git config --global --add safe.directory /home/runner/work/shell-tester/shell-tester 
+          # repo is owned by user and we intend to execute as root
+          make test
+        shell: alpine.sh --root {0}

--- a/internal/stage10.go
+++ b/internal/stage10.go
@@ -39,7 +39,7 @@ func testCd1(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedOutput: fmt.Sprintf(`cd: %s: No such file or directory`, directory),
 		FallbackPatterns: []*regexp.Regexp{
 			regexp.MustCompile(fmt.Sprintf(`^(can't cd to %s|((bash: )?cd: )?%s: No such file or directory)$`, directory, directory)),
-			regexp.MustCompile(`ash: cd: can't cd to ` + directory + `: No such file or directory`),
+			regexp.MustCompile(`^ash: cd: can't cd to ` + directory + `: No such file or directory$`),
 		},
 		SuccessMessage: "✓ Received error message",
 	}

--- a/internal/stage10.go
+++ b/internal/stage10.go
@@ -39,6 +39,7 @@ func testCd1(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedOutput: fmt.Sprintf(`cd: %s: No such file or directory`, directory),
 		FallbackPatterns: []*regexp.Regexp{
 			regexp.MustCompile(fmt.Sprintf(`^(can't cd to %s|((bash: )?cd: )?%s: No such file or directory)$`, directory, directory)),
+			regexp.MustCompile(`ash: cd: can't cd to ` + directory + `: No such file or directory`),
 		},
 		SuccessMessage: "✓ Received error message",
 	}

--- a/internal/test_cases/invalid_command_test_case.go
+++ b/internal/test_cases/invalid_command_test_case.go
@@ -55,5 +55,8 @@ func (t *InvalidCommandTestCase) getExpectedOutput() string {
 }
 
 func (t *InvalidCommandTestCase) getFallbackPatterns() []*regexp.Regexp {
-	return []*regexp.Regexp{regexp.MustCompile(`^(bash: )?` + t.Command + `: (command )?not found$`)}
+	return []*regexp.Regexp{
+		regexp.MustCompile(`^(bash: )?` + t.Command + `: (command )?not found$`),
+		regexp.MustCompile(`ash: ` + t.Command + `: not found$`),
+	}
 }

--- a/internal/test_cases/invalid_command_test_case.go
+++ b/internal/test_cases/invalid_command_test_case.go
@@ -57,6 +57,6 @@ func (t *InvalidCommandTestCase) getExpectedOutput() string {
 func (t *InvalidCommandTestCase) getFallbackPatterns() []*regexp.Regexp {
 	return []*regexp.Regexp{
 		regexp.MustCompile(`^(bash: )?` + t.Command + `: (command )?not found$`),
-		regexp.MustCompile(`ash: ` + t.Command + `: not found$`),
+		regexp.MustCompile(`^ash: ` + t.Command + `: not found$`),
 	}
 }


### PR DESCRIPTION
Updated the getFallbackPatterns method to include a new regex pattern for 'ash' shell errors, improving the robustness of command error handling in tests.