### PR TITLE
Add `BellAssertion` for terminal bell events

### DIFF
--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -30,7 +30,7 @@ func checkIfBellReceived(bellChannel chan bool) bool {
 	select {
 	case <-bellChannel:
 		return true
-	case <-time.After(50 * time.Millisecond): // Add reasonable timeout
+	case <-time.After(100 * time.Millisecond): // Add reasonable timeout
 		return false
 	}
 }

--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -4,7 +4,11 @@ import (
 	"time"
 )
 
-// BellAssertion asserts that ...
+const defaultBellTimeout = 100 * time.Millisecond
+
+// BellAssertion asserts that the bell callback function is called
+// by the virtual terminal, this can only happen if the user sends
+// /U0007 to the shell.
 type BellAssertion struct {
 	// Vt *virtual_terminal.VirtualTerminal
 	BellChannel chan bool
@@ -15,22 +19,25 @@ func (a BellAssertion) Inspect() string {
 }
 
 func (a BellAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
-	if !checkIfBellReceived(a.BellChannel) {
-		return 0, &AssertionError{
-			StartRowIndex: startRowIndex,
-			ErrorRowIndex: startRowIndex,
-			Message:       "Expected bell to ring, but it didn't",
-		}
-	} else {
+	if checkIfBellReceived(a.BellChannel) {
 		return 0, nil
+	}
+	return 0, &AssertionError{
+		StartRowIndex: startRowIndex,
+		ErrorRowIndex: startRowIndex,
+		Message:       "Expected bell to ring, but it didn't",
 	}
 }
 
+// checkIfBellReceived waits for a bell signal on the provided channel with a timeout.
+// Returns true if a signal is received, false if the timeout is reached.
 func checkIfBellReceived(bellChannel chan bool) bool {
 	select {
 	case <-bellChannel:
 		return true
-	case <-time.After(100 * time.Millisecond): // Add reasonable timeout
+	case <-time.After(defaultBellTimeout):
+		// This timeout is for reading the bell signal on the bellChannel
+		// Reading from term & processing happens in x/vt
 		return false
 	}
 }

--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -1,11 +1,5 @@
 package assertions
 
-import (
-	"time"
-)
-
-const defaultBellTimeout = 100 * time.Millisecond
-
 // BellAssertion asserts that the bell callback function is called
 // by the virtual terminal, this can only happen if the user sends
 // /U0007 to the shell.
@@ -29,15 +23,16 @@ func (a BellAssertion) Run(screenState [][]string, startRowIndex int) (processed
 	}
 }
 
-// checkIfBellReceived waits for a bell signal on the provided channel with a timeout.
-// Returns true if a signal is received, false if the timeout is reached.
+// checkIfBellReceived waits for a bell signal on the provided channel in a non-blocking way.
+// Returns true if a signal is received, false if no signal is received or if the channel is closed.
 func checkIfBellReceived(bellChannel chan bool) bool {
 	select {
-	case <-bellChannel:
-		return true
-	case <-time.After(defaultBellTimeout):
-		// This timeout is for reading the bell signal on the bellChannel
-		// Reading from term & processing happens in x/vt
+	case _, ok := <-bellChannel:
+		if ok {
+			return true
+		}
+		return false
+	default:
 		return false
 	}
 }

--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -1,0 +1,36 @@
+package assertions
+
+import (
+	"time"
+)
+
+// BellAssertion asserts that ...
+type BellAssertion struct {
+	// Vt *virtual_terminal.VirtualTerminal
+	BellChannel chan bool
+}
+
+func (a BellAssertion) Inspect() string {
+	return "BellAssertion"
+}
+
+func (a BellAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+	if !checkIfBellReceived(a.BellChannel) {
+		return 0, &AssertionError{
+			StartRowIndex: startRowIndex,
+			ErrorRowIndex: startRowIndex,
+			Message:       "Expected bell to ring, but it didn't",
+		}
+	} else {
+		return 0, nil
+	}
+}
+
+func checkIfBellReceived(bellChannel chan bool) bool {
+	select {
+	case <-bellChannel:
+		return true
+	case <-time.After(50 * time.Millisecond): // Add reasonable timeout
+		return false
+	}
+}

--- a/internal/test_cases/command_multiple_completions_test_case.go
+++ b/internal/test_cases/command_multiple_completions_test_case.go
@@ -73,9 +73,18 @@ func (t CommandMultipleCompletionsTestCase) Run(asserter *logged_shell_asserter.
 	}
 
 	if t.CheckForBell {
-		if err := RunBellAssertion(shell, logger); err != nil {
+		bellChannel := shell.VTBellChannel()
+		asserter.AddAssertion(assertions.BellAssertion{
+			BellChannel: bellChannel,
+		})
+		// Run the assertion, before sending the enter key
+		if err := asserter.AssertWithoutPrompt(); err != nil {
 			return err
 		}
+
+		logger.Successf("✓ Received bell")
+		// Pop the bell assertion after running
+		asserter.PopAssertion()
 	}
 
 	commandReflection := t.ExpectedReflection


### PR DESCRIPTION
Introduce a new `BellAssertion` to verify terminal bell events and refactor existing test cases to utilize this assertion, simplifying the handling of bell checks in command autocomplete and multiple completions scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BellAssertion` package for handling bell signal assertions in test cases.
	- Improved bell assertion logic in command autocomplete and multiple completions test cases.

- **Refactor**
	- Streamlined bell assertion handling in test case methods.
	- Removed redundant bell assertion functions.
	- Integrated bell assertion more directly into test case execution.

- **Bug Fixes**
	- Enhanced timeout and error handling for bell signal detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->