### PR TITLE
Enhance executable resolution test with multi-directory scenario

### DIFF
--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -24,17 +24,17 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 	// - The shell should continue searching PATH and find/execute e2
 	// - This verifies proper PATH traversal and permission checking
 	executableExpectedToNotBeFound := "my_exe"
-	executableDir, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+	executableExpectedToNotBeFoundDir, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
 		{CommandType: "signature_printer", CommandName: executableExpectedToNotBeFound, CommandMetadata: getRandomString()},
 	}, true)
 	if err != nil {
 		return err
 	}
-	notExePath := filepath.Join(executableDir, executableExpectedToNotBeFound)
+	notExePath := filepath.Join(executableExpectedToNotBeFoundDir, executableExpectedToNotBeFound)
 	currentPerms, _ := os.Stat(notExePath)
 	os.Chmod(notExePath, currentPerms.Mode() & ^os.FileMode(0o111))
 
-	executableDir, err = SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+	executableDir, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
 		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: getRandomString()},
 	}, true)
 	if err != nil {

--- a/internal/test_helpers/fixtures/ash/base/pass
+++ b/internal/test_helpers/fixtures/ash/base/pass
@@ -16,6 +16,7 @@ Debug = true
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
+[33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
@@ -29,13 +30,13 @@ Debug = true
 [33m[your-program] [0mmkdir is /bin/mkdir
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type my_exe
-[33m[your-program] [0mmy_exe is /tmp/baz/my_exe
+[33m[your-program] [0mmy_exe is /tmp/foo/my_exe
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_raspberry_command
 [33m[your-program] [0minvalid_raspberry_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_grape_command
-[33m[your-program] [0minvalid_grape_command: not found
+[33m[your-program] [0m$ type invalid_orange_command
+[33m[your-program] [0minvalid_orange_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-7] [0m[92mTest passed.[0m
@@ -51,22 +52,22 @@ Debug = true
 [33m[your-program] [0m$ type type
 [33m[your-program] [0mtype is a shell builtin
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_raspberry_command
-[33m[your-program] [0minvalid_raspberry_command: not found
+[33m[your-program] [0m$ type invalid_pineapple_command
+[33m[your-program] [0minvalid_pineapple_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_orange_command
-[33m[your-program] [0minvalid_orange_command: not found
+[33m[your-program] [0m$ type invalid_mango_command
+[33m[your-program] [0minvalid_mango_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-6] [0m[92mTest passed.[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: iz3[0m
 [33m[stage-5] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ echo pear orange
-[33m[your-program] [0mpear orange
+[33m[your-program] [0m$ echo raspberry orange
+[33m[your-program] [0mraspberry orange
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo raspberry blueberry apple
-[33m[your-program] [0mraspberry blueberry apple
+[33m[your-program] [0m$ echo strawberry orange mango
+[33m[your-program] [0mstrawberry orange mango
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-5] [0m[92mTest passed.[0m
@@ -95,13 +96,16 @@ Debug = true
 [33m[your-program] [0m$ invalid_command_4
 [33m[your-program] [0mash: invalid_command_4: not found
 [33m[stage-3] [0m[92m✓ Received command not found message[0m
+[33m[your-program] [0m$ invalid_command_5
+[33m[your-program] [0mash: invalid_command_5: not found
+[33m[stage-3] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ 
 [33m[stage-3] [0m[92mTest passed.[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cz2[0m
 [33m[stage-2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_blueberry_command
-[33m[your-program] [0mash: invalid_blueberry_command: not found
+[33m[your-program] [0m$ invalid_pineapple_command
+[33m[your-program] [0mash: invalid_pineapple_command: not found
 [33m[stage-2] [0m[92m✓ Received command not found message[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/ash/navigation/pass
+++ b/internal/test_helpers/fixtures/ash/navigation/pass
@@ -69,6 +69,7 @@ Debug = true
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
+[33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
@@ -82,10 +83,10 @@ Debug = true
 [33m[your-program] [0mmkdir is /bin/mkdir
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type my_exe
-[33m[your-program] [0mmy_exe is /tmp/foo/my_exe
+[33m[your-program] [0mmy_exe is /tmp/quz/my_exe
 [33m[stage-7] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_blueberry_command
-[33m[your-program] [0minvalid_blueberry_command: not found
+[33m[your-program] [0m$ type invalid_pear_command
+[33m[your-program] [0minvalid_pear_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_orange_command
 [33m[your-program] [0minvalid_orange_command: not found
@@ -104,8 +105,8 @@ Debug = true
 [33m[your-program] [0m$ type type
 [33m[your-program] [0mtype is a shell builtin
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_pear_command
-[33m[your-program] [0minvalid_pear_command: not found
+[33m[your-program] [0m$ type invalid_raspberry_command
+[33m[your-program] [0minvalid_raspberry_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_orange_command
 [33m[your-program] [0minvalid_orange_command: not found
@@ -115,22 +116,22 @@ Debug = true
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: iz3[0m
 [33m[stage-5] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ echo mango blueberry pear
-[33m[your-program] [0mmango blueberry pear
+[33m[your-program] [0m$ echo pineapple raspberry pear
+[33m[your-program] [0mpineapple raspberry pear
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo pear strawberry pineapple
-[33m[your-program] [0mpear strawberry pineapple
+[33m[your-program] [0m$ echo banana blueberry
+[33m[your-program] [0mbanana blueberry
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo raspberry mango blueberry
-[33m[your-program] [0mraspberry mango blueberry
+[33m[your-program] [0m$ echo grape orange
+[33m[your-program] [0mgrape orange
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: pn5[0m
 [33m[stage-4] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_grape_command
-[33m[your-program] [0mash: invalid_grape_command: not found
+[33m[your-program] [0m$ invalid_mango_command
+[33m[your-program] [0mash: invalid_mango_command: not found
 [33m[stage-4] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ exit 0
 [33m[stage-4] [0m[92m✓ Program exited successfully[0m
@@ -151,16 +152,13 @@ Debug = true
 [33m[your-program] [0m$ invalid_command_4
 [33m[your-program] [0mash: invalid_command_4: not found
 [33m[stage-3] [0m[92m✓ Received command not found message[0m
-[33m[your-program] [0m$ invalid_command_5
-[33m[your-program] [0mash: invalid_command_5: not found
-[33m[stage-3] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ 
 [33m[stage-3] [0m[92mTest passed.[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cz2[0m
 [33m[stage-2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_orange_command
-[33m[your-program] [0mash: invalid_orange_command: not found
+[33m[your-program] [0m$ invalid_mango_command
+[33m[your-program] [0mash: invalid_mango_command: not found
 [33m[stage-2] [0m[92m✓ Received command not found message[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/bash/base/pass
+++ b/internal/test_helpers/fixtures/bash/base/pass
@@ -16,26 +16,27 @@ Debug = true
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
+[33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
-[33m[your-program] [0mcat is /usr/bin/cat
+[33m[your-program] [0mcat is /bin/cat
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type cp
-[33m[your-program] [0mcp is /usr/bin/cp
+[33m[your-program] [0mcp is /bin/cp
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type mkdir
-[33m[your-program] [0mmkdir is /usr/bin/mkdir
+[33m[your-program] [0mmkdir is /bin/mkdir
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type my_exe
-[33m[your-program] [0mmy_exe is /tmp/baz/my_exe
+[33m[your-program] [0mmy_exe is /tmp/foo/my_exe
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_raspberry_command
 [33m[your-program] [0mbash: type: invalid_raspberry_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_grape_command
-[33m[your-program] [0mbash: type: invalid_grape_command: not found
+[33m[your-program] [0m$ type invalid_orange_command
+[33m[your-program] [0mbash: type: invalid_orange_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-7] [0m[92mTest passed.[0m
@@ -51,22 +52,22 @@ Debug = true
 [33m[your-program] [0m$ type type
 [33m[your-program] [0mtype is a shell builtin
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_raspberry_command
-[33m[your-program] [0mbash: type: invalid_raspberry_command: not found
+[33m[your-program] [0m$ type invalid_pineapple_command
+[33m[your-program] [0mbash: type: invalid_pineapple_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_orange_command
-[33m[your-program] [0mbash: type: invalid_orange_command: not found
+[33m[your-program] [0m$ type invalid_mango_command
+[33m[your-program] [0mbash: type: invalid_mango_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-6] [0m[92mTest passed.[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: iz3[0m
 [33m[stage-5] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ echo pear orange
-[33m[your-program] [0mpear orange
+[33m[your-program] [0m$ echo raspberry orange
+[33m[your-program] [0mraspberry orange
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo raspberry blueberry apple
-[33m[your-program] [0mraspberry blueberry apple
+[33m[your-program] [0m$ echo strawberry orange mango
+[33m[your-program] [0mstrawberry orange mango
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-5] [0m[92mTest passed.[0m
@@ -96,13 +97,16 @@ Debug = true
 [33m[your-program] [0m$ invalid_command_4
 [33m[your-program] [0mbash: invalid_command_4: command not found
 [33m[stage-3] [0m[92m✓ Received command not found message[0m
+[33m[your-program] [0m$ invalid_command_5
+[33m[your-program] [0mbash: invalid_command_5: command not found
+[33m[stage-3] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ 
 [33m[stage-3] [0m[92mTest passed.[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cz2[0m
 [33m[stage-2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_blueberry_command
-[33m[your-program] [0mbash: invalid_blueberry_command: command not found
+[33m[your-program] [0m$ invalid_pineapple_command
+[33m[your-program] [0mbash: invalid_pineapple_command: command not found
 [33m[stage-2] [0m[92m✓ Received command not found message[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/bash/navigation/pass
+++ b/internal/test_helpers/fixtures/bash/navigation/pass
@@ -69,23 +69,24 @@ Debug = true
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
+[33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
-[33m[your-program] [0mcat is /usr/bin/cat
+[33m[your-program] [0mcat is /bin/cat
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type cp
-[33m[your-program] [0mcp is /usr/bin/cp
+[33m[your-program] [0mcp is /bin/cp
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type mkdir
-[33m[your-program] [0mmkdir is /usr/bin/mkdir
+[33m[your-program] [0mmkdir is /bin/mkdir
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type my_exe
-[33m[your-program] [0mmy_exe is /tmp/foo/my_exe
+[33m[your-program] [0mmy_exe is /tmp/quz/my_exe
 [33m[stage-7] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_blueberry_command
-[33m[your-program] [0mbash: type: invalid_blueberry_command: not found
+[33m[your-program] [0m$ type invalid_pear_command
+[33m[your-program] [0mbash: type: invalid_pear_command: not found
 [33m[stage-7] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_orange_command
 [33m[your-program] [0mbash: type: invalid_orange_command: not found
@@ -104,8 +105,8 @@ Debug = true
 [33m[your-program] [0m$ type type
 [33m[your-program] [0mtype is a shell builtin
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ type invalid_pear_command
-[33m[your-program] [0mbash: type: invalid_pear_command: not found
+[33m[your-program] [0m$ type invalid_raspberry_command
+[33m[your-program] [0mbash: type: invalid_raspberry_command: not found
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ type invalid_orange_command
 [33m[your-program] [0mbash: type: invalid_orange_command: not found
@@ -115,22 +116,22 @@ Debug = true
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: iz3[0m
 [33m[stage-5] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ echo mango blueberry pear
-[33m[your-program] [0mmango blueberry pear
+[33m[your-program] [0m$ echo pineapple raspberry pear
+[33m[your-program] [0mpineapple raspberry pear
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo pear strawberry pineapple
-[33m[your-program] [0mpear strawberry pineapple
+[33m[your-program] [0m$ echo banana blueberry
+[33m[your-program] [0mbanana blueberry
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo raspberry mango blueberry
-[33m[your-program] [0mraspberry mango blueberry
+[33m[your-program] [0m$ echo grape orange
+[33m[your-program] [0mgrape orange
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ 
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: pn5[0m
 [33m[stage-4] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_grape_command
-[33m[your-program] [0mbash: invalid_grape_command: command not found
+[33m[your-program] [0m$ invalid_mango_command
+[33m[your-program] [0mbash: invalid_mango_command: command not found
 [33m[stage-4] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ exit 0
 [33m[stage-4] [0m[92m✓ Program exited successfully[0m
@@ -152,16 +153,13 @@ Debug = true
 [33m[your-program] [0m$ invalid_command_4
 [33m[your-program] [0mbash: invalid_command_4: command not found
 [33m[stage-3] [0m[92m✓ Received command not found message[0m
-[33m[your-program] [0m$ invalid_command_5
-[33m[your-program] [0mbash: invalid_command_5: command not found
-[33m[stage-3] [0m[92m✓ Received command not found message[0m
 [33m[your-program] [0m$ 
 [33m[stage-3] [0m[92mTest passed.[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cz2[0m
 [33m[stage-2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m$ invalid_orange_command
-[33m[your-program] [0mbash: invalid_orange_command: command not found
+[33m[your-program] [0m$ invalid_mango_command
+[33m[your-program] [0mbash: invalid_mango_command: command not found
 [33m[stage-2] [0m[92m✓ Received command not found message[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 


### PR DESCRIPTION
Improve the executable resolution test by adding a scenario that includes multiple directories, ensuring the correct executable is found even when another with the same name exists but lacks executable permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for handling custom executables with varying permissions in testing scenarios.
- **Tests**
	- Updated command scenarios and outputs across multiple stages, including changes to the `PATH` variable and specific command checks.
	- Introduced new invalid command checks to ensure comprehensive testing coverage.
- **Documentation**
	- Added comments to clarify expected behavior regarding PATH resolution and permission checking for executables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->