### PR TITLE
CC-1678 pty not working with readline in Go

### DIFF
--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -71,18 +71,19 @@ func (b *ShellExecutable) Start(args ...string) error {
 	cmd := exec.Command(b.executable.Path, args...)
 	cmd.Env = b.env.Sorted()
 
+	b.cmd = cmd
+	b.vt = virtual_terminal.NewStandardVT()
+
 	winsize := &ptylib.Winsize{
-		Rows: 100,
-		Cols: 120,
+		Rows: uint16(b.vt.GetRowCount()),
+		Cols: uint16(b.vt.GetColumnCount()),
 	}
 	pty, err := ptylib.StartWithSize(cmd, winsize)
 	if err != nil {
 		return fmt.Errorf("Failed to execute %s: %v", b.executable.Path, err)
 	}
 
-	b.cmd = cmd
 	b.pty = pty
-	b.vt = virtual_terminal.NewStandardVT()
 	b.ptyReader = condition_reader.NewConditionReader(io.TeeReader(b.pty, b.vt))
 
 	return nil

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -71,7 +71,11 @@ func (b *ShellExecutable) Start(args ...string) error {
 	cmd := exec.Command(b.executable.Path, args...)
 	cmd.Env = b.env.Sorted()
 
-	pty, err := ptylib.Start(cmd)
+	winsize := &ptylib.Winsize{
+		Rows: 24,
+		Cols: 80,
+	}
+	pty, err := ptylib.StartWithSize(cmd, winsize)
 	if err != nil {
 		return fmt.Errorf("Failed to execute %s: %v", b.executable.Path, err)
 	}

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -72,8 +72,8 @@ func (b *ShellExecutable) Start(args ...string) error {
 	cmd.Env = b.env.Sorted()
 
 	winsize := &ptylib.Winsize{
-		Rows: 24,
-		Cols: 80,
+		Rows: 100,
+		Cols: 120,
 	}
 	pty, err := ptylib.StartWithSize(cmd, winsize)
 	if err != nil {

--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -79,6 +79,14 @@ func (vt *VirtualTerminal) GetScreenState() [][]string {
 	return screenState
 }
 
+func (vt *VirtualTerminal) GetColumnCount() int {
+	return vt.cols
+}
+
+func (vt *VirtualTerminal) GetRowCount() int {
+	return vt.rows
+}
+
 func (vt *VirtualTerminal) GetRow(row int) []string {
 	screenState := make([]string, vt.cols)
 	for j := 0; j < vt.cols; j++ {


### PR DESCRIPTION
**Symptom**:

- tab (09) went in, but bell (07) came out:

![image](https://github.com/user-attachments/assets/6f04377c-d094-42e2-9d19-f7d540eb1456)

**Cause**:

- If terminal width is 0, chzyer/readline will ring bell immediately when autocompleting.

https://github.com/chzyer/readline/blob/fcb4d7d9a9f653462a7adf557fb1f931f00391f2/operation.go#L175-L185
<img width="361" alt="image" src="https://github.com/user-attachments/assets/be73e307-1037-4ae0-b377-09e39d841d22" />

https://github.com/chzyer/readline/blob/fcb4d7d9a9f653462a7adf557fb1f931f00391f2/complete.go#L67-L70
<img width="349" alt="image" src="https://github.com/user-attachments/assets/dcd97bd9-cf7c-4344-9634-4efbaffdae0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced terminal session initialization by setting predefined display dimensions for improved consistency in interactive terminal experiences.
	- Added methods to retrieve the number of columns and rows in the virtual terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->