### PR TITLE
[#mg5] Add logging PATH

### DIFF
--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -62,6 +62,10 @@ func (b *ShellExecutable) AddToPath(dir string) {
 	b.env.Set("PATH", fmt.Sprintf("%s:%s", dir, b.env.Get("PATH")))
 }
 
+func (b *ShellExecutable) GetPath() string {
+	return b.env.Get("PATH")
+}
+
 func (b *ShellExecutable) Start(args ...string) error {
 	b.stageLogger.Infof(b.getInitialLogLine(args...))
 

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -62,10 +62,6 @@ func (b *ShellExecutable) AddToPath(dir string) {
 	b.env.Set("PATH", fmt.Sprintf("%s:%s", dir, b.env.Get("PATH")))
 }
 
-func (b *ShellExecutable) GetPath() string {
-	return b.env.Get("PATH")
-}
-
 func (b *ShellExecutable) Start(args ...string) error {
 	b.stageLogger.Infof(b.getInitialLogLine(args...))
 

--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -41,6 +42,8 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 	logAvailableExecutables(logger, []string{executableName})
+	logPath(logger, shell)
+
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
 
 	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
@@ -76,4 +79,11 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	return logAndQuit(asserter, nil)
+}
+
+func logPath(logger *logger.Logger, shell *shell_executable.ShellExecutable) {
+	logger.UpdateSecondaryPrefix("setup")
+	logger.Infof("The contents of PATH are:")
+	logger.Infof("%s", shell.GetPath())
+	logger.ResetSecondaryPrefix()
 }

--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -84,15 +84,15 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 
 func logPath(shell *shell_executable.ShellExecutable, logger *logger.Logger, prefixLength int) {
 	path := shell.GetPath()
-	lineLimit := 80 - prefixLength
+	lengthLimit := 80 - prefixLength
 
-	if len(path) > lineLimit {
+	if len(path) > lengthLimit {
 		pathChunks := strings.Split(path, ":")
 		path = ""
 
 		for _, chunk := range pathChunks {
 			// 4 is reserved for the colon and the ellipsis
-			if len(path)+len(chunk) <= lineLimit-4 {
+			if len(path)+len(chunk) <= lengthLimit-4 {
 				path += chunk + ":"
 			} else {
 				path += "..."

--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -42,7 +42,7 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 	logAvailableExecutables(logger, []string{executableName})
-	logPath(logger, shell)
+	debugLogPath(logger, shell)
 
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
 
@@ -81,9 +81,9 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 	return logAndQuit(asserter, nil)
 }
 
-func logPath(logger *logger.Logger, shell *shell_executable.ShellExecutable) {
+func debugLogPath(logger *logger.Logger, shell *shell_executable.ShellExecutable) {
 	logger.UpdateSecondaryPrefix("setup")
-	logger.Infof("The contents of PATH are:")
-	logger.Infof("%s", shell.GetPath())
+	logger.Debugf("The contents of PATH are:")
+	logger.Debugf("%s", shell.GetPath())
 	logger.ResetSecondaryPrefix()
 }

--- a/internal/stage7.go
+++ b/internal/stage7.go
@@ -41,9 +41,9 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-	logAvailableExecutables(logger, []string{executableName})
-	debugLogPath(logger, shell)
 
+	logDemoPath(logger, executableExpectedToNotBeFoundDir, executableDir)
+	logAvailableExecutables(logger, []string{executableName})
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
 
 	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
@@ -81,9 +81,14 @@ func testType2(stageHarness *test_case_harness.TestCaseHarness) error {
 	return logAndQuit(asserter, nil)
 }
 
-func debugLogPath(logger *logger.Logger, shell *shell_executable.ShellExecutable) {
+func logDemoPath(logger *logger.Logger, paths ...string) {
+	demoPath := "/usr/bin:/bin:..."
+	for _, path := range paths {
+		demoPath = path + ":" + demoPath
+	}
+
 	logger.UpdateSecondaryPrefix("setup")
-	logger.Debugf("The contents of PATH are:")
-	logger.Debugf("%s", shell.GetPath())
+	logger.Infof("Now PATH looks like this:")
+	logger.Infof("%s", demoPath)
 	logger.ResetSecondaryPrefix()
 }

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -153,6 +153,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"[your-program] my_exe is <path>": {regexp.MustCompile(`\[your-program\] .{4}my_exe is .*`)},
 		"[your-program] <cwd>":            {regexp.MustCompile(`\[your-program\] .{4}/(workspaces|home|Users)/.*`)},
 		"ls-la-output-line":               {regexp.MustCompile(`-rw-r--r-- .*`)},
+		"PATH is now: <path>":             {regexp.MustCompile(`PATH is now: .*`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/test_helpers/fixtures/ash/base/pass
+++ b/internal/test_helpers/fixtures/ash/base/pass
@@ -17,8 +17,7 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
-[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/usr/bin:/bin:...[0m
+[33m[stage-7] [setup] [0m[94mPATH is now: /tmp/foo:/tmp/qux:/foobar:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m

--- a/internal/test_helpers/fixtures/ash/base/pass
+++ b/internal/test_helpers/fixtures/ash/base/pass
@@ -17,6 +17,8 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
+[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m

--- a/internal/test_helpers/fixtures/ash/navigation/pass
+++ b/internal/test_helpers/fixtures/ash/navigation/pass
@@ -70,6 +70,8 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
+[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m

--- a/internal/test_helpers/fixtures/ash/navigation/pass
+++ b/internal/test_helpers/fixtures/ash/navigation/pass
@@ -70,8 +70,7 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
-[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/usr/bin:/bin:...[0m
+[33m[stage-7] [setup] [0m[94mPATH is now: /tmp/foo:/tmp/qux:/foobar:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m

--- a/internal/test_helpers/fixtures/bash/base/pass
+++ b/internal/test_helpers/fixtures/bash/base/pass
@@ -17,8 +17,7 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
-[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/usr/bin:/bin:...[0m
+[33m[stage-7] [setup] [0m[94mPATH is now: /tmp/foo:/tmp/qux:/foobar:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m

--- a/internal/test_helpers/fixtures/bash/base/pass
+++ b/internal/test_helpers/fixtures/bash/base/pass
@@ -19,6 +19,8 @@ Debug = true
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
+[33m[stage-7] [setup] [0m[94mThe contents of PATH are:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/opt/homebrew/Cellar/go/1.24.3/libexec/bin:/Users/andy/.opam/5.2.0/bin:/Users/andy/Library/pnpm:/Users/andy/.nvm/versions/node/v20.19.1/bin:/Users/andy/.cargo/bin:/Users/andy/.rbenv/shims:/opt/homebrew/opt/rustup/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/go@1.23/bin:/opt/homebrew/opt/dart@2.19/bin:/opt/homebrew/anaconda3/bin:/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/Wireshark.app/Contents/MacOS:/Applications/iTerm.app/Contents/Resources/utilities:/Users/andy/.local/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/base/pass
+++ b/internal/test_helpers/fixtures/bash/base/pass
@@ -17,10 +17,10 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/baz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
+[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
-[33m[stage-7] [setup] [0m[36mThe contents of PATH are:[0m
-[33m[stage-7] [setup] [0m[36m/tmp/foo:/tmp/baz:/opt/hostedtoolcache/go/1.23.8/x64/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.23.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/base/pass
+++ b/internal/test_helpers/fixtures/bash/base/pass
@@ -19,8 +19,8 @@ Debug = true
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
-[33m[stage-7] [setup] [0m[94mThe contents of PATH are:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/foo:/tmp/baz:/opt/homebrew/Cellar/go/1.24.3/libexec/bin:/Users/andy/.opam/5.2.0/bin:/Users/andy/Library/pnpm:/Users/andy/.nvm/versions/node/v20.19.1/bin:/Users/andy/.cargo/bin:/Users/andy/.rbenv/shims:/opt/homebrew/opt/rustup/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/go@1.23/bin:/opt/homebrew/opt/dart@2.19/bin:/opt/homebrew/anaconda3/bin:/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/Wireshark.app/Contents/MacOS:/Applications/iTerm.app/Contents/Resources/utilities:/Users/andy/.local/bin[0m
+[33m[stage-7] [setup] [0m[36mThe contents of PATH are:[0m
+[33m[stage-7] [setup] [0m[36m/tmp/foo:/tmp/baz:/opt/hostedtoolcache/go/1.23.8/x64/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.23.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/navigation/pass
+++ b/internal/test_helpers/fixtures/bash/navigation/pass
@@ -70,10 +70,10 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
+[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
-[33m[stage-7] [setup] [0m[36mThe contents of PATH are:[0m
-[33m[stage-7] [setup] [0m[36m/tmp/quz:/tmp/foo:/opt/hostedtoolcache/go/1.23.8/x64/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.23.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/navigation/pass
+++ b/internal/test_helpers/fixtures/bash/navigation/pass
@@ -72,8 +72,8 @@ Debug = true
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
-[33m[stage-7] [setup] [0m[94mThe contents of PATH are:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/opt/homebrew/Cellar/go/1.24.3/libexec/bin:/Users/andy/.opam/5.2.0/bin:/Users/andy/Library/pnpm:/Users/andy/.nvm/versions/node/v20.19.1/bin:/Users/andy/.cargo/bin:/Users/andy/.rbenv/shims:/opt/homebrew/opt/rustup/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/go@1.23/bin:/opt/homebrew/opt/dart@2.19/bin:/opt/homebrew/anaconda3/bin:/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/Wireshark.app/Contents/MacOS:/Applications/iTerm.app/Contents/Resources/utilities:/Users/andy/.local/bin[0m
+[33m[stage-7] [setup] [0m[36mThe contents of PATH are:[0m
+[33m[stage-7] [setup] [0m[36m/tmp/quz:/tmp/foo:/opt/hostedtoolcache/go/1.23.8/x64/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.23.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/navigation/pass
+++ b/internal/test_helpers/fixtures/bash/navigation/pass
@@ -72,6 +72,8 @@ Debug = true
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
+[33m[stage-7] [setup] [0m[94mThe contents of PATH are:[0m
+[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/opt/homebrew/Cellar/go/1.24.3/libexec/bin:/Users/andy/.opam/5.2.0/bin:/Users/andy/Library/pnpm:/Users/andy/.nvm/versions/node/v20.19.1/bin:/Users/andy/.cargo/bin:/Users/andy/.rbenv/shims:/opt/homebrew/opt/rustup/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/go@1.23/bin:/opt/homebrew/opt/dart@2.19/bin:/opt/homebrew/anaconda3/bin:/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/Wireshark.app/Contents/MacOS:/Applications/iTerm.app/Contents/Resources/utilities:/Users/andy/.local/bin[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m$ type cat
 [33m[your-program] [0mcat is /usr/bin/cat

--- a/internal/test_helpers/fixtures/bash/navigation/pass
+++ b/internal/test_helpers/fixtures/bash/navigation/pass
@@ -70,8 +70,7 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: mg5[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/foo:$PATH[0m
 [33m[stage-7] [setup] [0m[94mexport PATH=/tmp/quz:$PATH[0m
-[33m[stage-7] [setup] [0m[94mNow PATH looks like this:[0m
-[33m[stage-7] [setup] [0m[94m/tmp/quz:/tmp/foo:/usr/bin:/bin:...[0m
+[33m[stage-7] [setup] [0m[94mPATH is now: /tmp/foo:/tmp/qux:/foobar:/usr/bin:/bin:...[0m
 [33m[stage-7] [setup] [0m[94mAvailable executables:[0m
 [33m[stage-7] [setup] [0m[94m- my_exe[0m
 [33m[stage-7] [0m[94mRunning ./your_shell.sh[0m


### PR DESCRIPTION
Context: https://secure.helpscout.net/conversation/2934950345/8280/

Fixture now:

- Mac with deliberately added short chunks:

<img width="863" alt="image" src="https://github.com/user-attachments/assets/8af069de-d901-4e01-9421-ca0788ce7d59" />

- Ubuntu with longer chunks that didn't fit into a 80-char line:

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/adc5a790-ba94-4bb8-b54f-0f3c7ef8c18d" />


---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added explicit display of the PATH environment variable during the setup phase of Stage 7 in test scenarios, providing clearer visibility into test environment configuration.
  - Introduced detailed logging of the composed PATH environment state during test setup for improved diagnostics.
  - Added a method to retrieve the current PATH environment variable value within the shell execution context for better environment introspection.

- **Documentation**
  - Enhanced informational output in test scripts to show the current PATH value for improved transparency during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->