### PR TITLE
Improve error message in FileContentAssertion to include file path

### DIFF
--- a/internal/assertions/file_content_assertion.go
+++ b/internal/assertions/file_content_assertion.go
@@ -35,7 +35,7 @@ func (t FileContentAssertion) Run(screenState [][]string, startRowIndex int) (pr
 		return processedRowCount, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
-			Message:       fmt.Sprintf("Expected %s contains (%q) but received %q", t.FilePath, t.ExpectedContent, fileContent),
+			Message:       fmt.Sprintf("Expected %s to contain %q but received %q", t.FilePath, t.ExpectedContent, fileContent),
 		}
 	}
 

--- a/internal/assertions/file_content_assertion.go
+++ b/internal/assertions/file_content_assertion.go
@@ -35,7 +35,7 @@ func (t FileContentAssertion) Run(screenState [][]string, startRowIndex int) (pr
 		return processedRowCount, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
-			Message:       fmt.Sprintf("Expected (%q) contains (%q) but received %q", t.FilePath, t.ExpectedContent, fileContent),
+			Message:       fmt.Sprintf("Expected %s contains (%q) but received %q", t.FilePath, t.ExpectedContent, fileContent),
 		}
 	}
 

--- a/internal/assertions/file_content_assertion.go
+++ b/internal/assertions/file_content_assertion.go
@@ -35,7 +35,7 @@ func (t FileContentAssertion) Run(screenState [][]string, startRowIndex int) (pr
 		return processedRowCount, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
-			Message:       fmt.Sprintf("Expected file content (%q) but received %q", t.ExpectedContent, fileContent),
+			Message:       fmt.Sprintf("Expected (%q) contains (%q) but received %q", t.FilePath, t.ExpectedContent, fileContent),
 		}
 	}
 


### PR DESCRIPTION
**Issue:**

It's hard to tell the error is related to which file.

**Context:**

https://forum.codecrafters.io/t/tests-for-stage-un3-redirection-append-stderr/11150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for file content mismatches by including the file path and clarifying the expected content details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->