### PR TITLE
Simplify `ls` command and update error message in stage `p3`

### DIFF
--- a/internal/stage_p3.go
+++ b/internal/stage_p3.go
@@ -19,6 +19,7 @@ func testP3(stageHarness *test_case_harness.TestCaseHarness) error {
 	shell := shell_executable.NewShellExecutable(stageHarness)
 	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
 		{CommandType: "cat", CommandName: CUSTOM_CAT_COMMAND, CommandMetadata: ""},
+		{CommandType: "grep", CommandName: CUSTOM_GREP_COMMAND, CommandMetadata: ""},
 		{CommandType: "head", CommandName: CUSTOM_HEAD_COMMAND, CommandMetadata: ""},
 		{CommandType: "ls", CommandName: CUSTOM_LS_COMMAND, CommandMetadata: ""},
 		{CommandType: "wc", CommandName: CUSTOM_WC_COMMAND, CommandMetadata: ""},

--- a/internal/stage_p3.go
+++ b/internal/stage_p3.go
@@ -20,6 +20,7 @@ func testP3(stageHarness *test_case_harness.TestCaseHarness) error {
 	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
 		{CommandType: "cat", CommandName: CUSTOM_CAT_COMMAND, CommandMetadata: ""},
 		{CommandType: "head", CommandName: CUSTOM_HEAD_COMMAND, CommandMetadata: ""},
+		{CommandType: "ls", CommandName: CUSTOM_LS_COMMAND, CommandMetadata: ""},
 		{CommandType: "wc", CommandName: CUSTOM_WC_COMMAND, CommandMetadata: ""},
 	}, false)
 	if err != nil {
@@ -83,12 +84,13 @@ func testP3(stageHarness *test_case_harness.TestCaseHarness) error {
 	sort.Ints(randomUniqueFileNames)
 	availableEntries := randomUniqueFileNames[1:4]
 
-	input = fmt.Sprintf(`ls -la %s | tail -n 5 | head -n 3 | grep "f-%d"`, newRandomDir, availableEntries[2])
+	input = fmt.Sprintf(`ls %s | tail -n 5 | head -n 3 | grep "f-%d"`, newRandomDir, availableEntries[2])
+	expectedOutput = fmt.Sprintf("f-%d", availableEntries[2])
 	expectedRegexPattern := fmt.Sprintf("^[rwx-]* .* f-%d", availableEntries[2])
 
 	singleLineTestCase2 := test_cases.CommandResponseTestCase{
 		Command:          input,
-		ExpectedOutput:   "NIL",
+		ExpectedOutput:   expectedOutput,
 		FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(expectedRegexPattern)},
 		SuccessMessage:   "✓ Received expected output",
 	}

--- a/internal/stage_p3.go
+++ b/internal/stage_p3.go
@@ -86,7 +86,7 @@ func testP3(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	input = fmt.Sprintf(`ls %s | tail -n 5 | head -n 3 | grep "f-%d"`, newRandomDir, availableEntries[2])
 	expectedOutput = fmt.Sprintf("f-%d", availableEntries[2])
-	expectedRegexPattern := fmt.Sprintf("^[rwx-]* .* f-%d", availableEntries[2])
+	expectedRegexPattern := fmt.Sprintf("^f-%d$", availableEntries[2])
 
 	singleLineTestCase2 := test_cases.CommandResponseTestCase{
 		Command:          input,

--- a/internal/test_helpers/fixtures/ash/pipelines/pass
+++ b/internal/test_helpers/fixtures/ash/pipelines/pass
@@ -44,8 +44,8 @@ Debug = true
 [33m[stage-1] [setup] [0m[94mecho -n "mango" > "/tmp/baz/f-56"[0m
 [33m[stage-1] [setup] [0m[94mecho -n "grape" > "/tmp/baz/f-19"[0m
 [33m[stage-1] [setup] [0m[94mecho -n "blueberry" > "/tmp/baz/f-42"[0m
-[33m[your-program] [0m$ ls -la /tmp/baz | tail -n 5 | head -n 3 | grep "f-42"
-[33m[your-program] [0m-rw-r--r-- 1 vscode vscode     9 May  1 16:17 f-42
+[33m[your-program] [0m$ ls /tmp/baz | tail -n 5 | head -n 3 | grep "f-42"
+[33m[your-program] [0mf-42
 [33m[stage-1] [0m[92m✓ Received expected output[0m
 [33m[your-program] [0m$ 
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/bash/pipelines/pass
+++ b/internal/test_helpers/fixtures/bash/pipelines/pass
@@ -44,8 +44,8 @@ Debug = true
 [33m[stage-1] [setup] [0m[94mecho -n "mango" > "/tmp/baz/f-56"[0m
 [33m[stage-1] [setup] [0m[94mecho -n "grape" > "/tmp/baz/f-19"[0m
 [33m[stage-1] [setup] [0m[94mecho -n "blueberry" > "/tmp/baz/f-42"[0m
-[33m[your-program] [0m$ ls -la /tmp/baz | tail -n 5 | head -n 3 | grep "f-42"
-[33m[your-program] [0m-rw-r--r-- 1 vscode vscode     9 May  1 16:17 f-42
+[33m[your-program] [0m$ ls /tmp/baz | tail -n 5 | head -n 3 | grep "f-42"
+[33m[your-program] [0mf-42
 [33m[stage-1] [0m[92m✓ Received expected output[0m
 [33m[your-program] [0m$ 
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -12,6 +12,7 @@ var SMALL_WORDS = []string{"foo", "bar", "baz", "qux", "quz"}
 var LARGE_WORDS = []string{"hello", "world", "test", "example", "shell", "script"}
 
 const CUSTOM_CAT_COMMAND = "cat"
+const CUSTOM_GREP_COMMAND = "grep"
 const CUSTOM_HEAD_COMMAND = "head"
 const CUSTOM_LS_COMMAND = "ls"
 const CUSTOM_TAIL_COMMAND = "tail"


### PR DESCRIPTION
This pull request includes updates to the `testP3` function in `internal/stage_p3.go` and adjustments to test fixtures in `internal/test_helpers/fixtures`. The changes primarily focus on modifying command behavior and expected outputs for test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test commands to use simplified file listing, resulting in output showing only filenames instead of detailed file information.
	- Adjusted expected test outputs to match the new simplified format.
	- Added support for custom "grep" and "ls" commands in test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->