### PR TITLE
Improve test cases for single and double quotes #NI6 #TG6

### DIFF
--- a/internal/stage_q1.go
+++ b/internal/stage_q1.go
@@ -44,17 +44,17 @@ func testQ1(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	L := random.RandomElementsFromArray(LARGE_WORDS, 5)
+	L := random.RandomElementsFromArray(LARGE_WORDS, 6)
 	inputs := []string{
 		fmt.Sprintf(`echo '%s %s'`, L[0], L[1]),
 		fmt.Sprintf(`echo %s     %s`, L[1], L[4]),
-		fmt.Sprintf(`echo '%s     %s' '%s''%s'`, L[2], L[3], L[4], L[0]),
+		fmt.Sprintf(`echo '%s     %s' '%s''%s' %s''%s`, L[2], L[3], L[4], L[0], L[1], L[5]),
 		fmt.Sprintf(`%s '%s' '%s' '%s'`, CUSTOM_CAT_COMMAND, filePaths[0], filePaths[1], filePaths[2]),
 	}
 	expectedOutputs := []string{
 		fmt.Sprintf("%s %s", L[0], L[1]),
 		fmt.Sprintf("%s %s", L[1], L[4]),
-		fmt.Sprintf("%s     %s %s%s", L[2], L[3], L[4], L[0]),
+		fmt.Sprintf("%s     %s %s%s %s%s", L[2], L[3], L[4], L[0], L[1], L[5]),
 		fileContents[0] + fileContents[1] + strings.TrimRight(fileContents[2], "\n"),
 	}
 	if err := writeFiles(filePaths, fileContents, logger); err != nil {

--- a/internal/stage_q2.go
+++ b/internal/stage_q2.go
@@ -50,13 +50,13 @@ func testQ2(stageHarness *test_case_harness.TestCaseHarness) error {
 	inputs := []string{
 		fmt.Sprintf(`echo "%s %s"`, L[0], L[1]),
 		fmt.Sprintf(`echo "%s  %s"  "%s""%s"`, L[1], L[2], L[3], L[0]),
-		fmt.Sprintf(`echo "%s"  "%s's"  "%s"`, L[3], L[4], L[1]),
+		fmt.Sprintf(`echo "%s"  "%s's"  %s""%s`, L[3], L[4], L[1], L[2]),
 		fmt.Sprintf(`%s "%s" "%s" "%s"`, CUSTOM_CAT_COMMAND, filePaths[0], filePaths[1], filePaths[2]),
 	}
 	expectedOutputs := []string{
 		fmt.Sprintf("%s %s", L[0], L[1]),
 		fmt.Sprintf("%s  %s %s%s", L[1], L[2], L[3], L[0]),
-		fmt.Sprintf(`%s %s's %s`, L[3], L[4], L[1]),
+		fmt.Sprintf(`%s %s's %s%s`, L[3], L[4], L[1], L[2]),
 		fileContents[0] + fileContents[1] + strings.TrimRight(fileContents[2], "\n"),
 	}
 	if err := writeFiles(filePaths, fileContents, logger); err != nil {

--- a/internal/test_helpers/fixtures/ash/quoting/pass
+++ b/internal/test_helpers/fixtures/ash/quoting/pass
@@ -12,8 +12,8 @@ Debug = true
 [33m[your-program] [0m$ echo example     shell
 [33m[your-program] [0mexample shell
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo 'hello     test' 'shell''script'
-[33m[your-program] [0mhello     test shellscript
+[33m[your-program] [0m$ echo 'hello     test' 'shell''script' example''world
+[33m[your-program] [0mhello     test shellscript exampleworld
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ cat '/tmp/foo/f   24' '/tmp/foo/f   61' '/tmp/foo/f   80'
 [33m[your-program] [0mpineapple grape.pineapple orange.blueberry strawberry.
@@ -33,8 +33,8 @@ Debug = true
 [33m[your-program] [0m$ echo "world  example"  "script""shell"
 [33m[your-program] [0mworld  example scriptshell
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo "script"  "hello's"  "world"
-[33m[your-program] [0mscript hello's world
+[33m[your-program] [0m$ echo "script"  "hello's"  world""example
+[33m[your-program] [0mscript hello's worldexample
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ cat "/tmp/bar/f 58" "/tmp/bar/f   73" "/tmp/bar/f's38"
 [33m[your-program] [0morange blueberry.grape pineapple.raspberry mango.

--- a/internal/test_helpers/fixtures/bash/quoting/pass
+++ b/internal/test_helpers/fixtures/bash/quoting/pass
@@ -12,8 +12,8 @@ Debug = true
 [33m[your-program] [0m$ echo example     shell
 [33m[your-program] [0mexample shell
 [33m[stage-6] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo 'hello     test' 'shell''script'
-[33m[your-program] [0mhello     test shellscript
+[33m[your-program] [0m$ echo 'hello     test' 'shell''script' example''world
+[33m[your-program] [0mhello     test shellscript exampleworld
 [33m[stage-6] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ cat '/tmp/foo/f   24' '/tmp/foo/f   61' '/tmp/foo/f   80'
 [33m[your-program] [0mpineapple grape.pineapple orange.blueberry strawberry.
@@ -33,8 +33,8 @@ Debug = true
 [33m[your-program] [0m$ echo "world  example"  "script""shell"
 [33m[your-program] [0mworld  example scriptshell
 [33m[stage-5] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m$ echo "script"  "hello's"  "world"
-[33m[your-program] [0mscript hello's world
+[33m[your-program] [0m$ echo "script"  "hello's"  world""example
+[33m[your-program] [0mscript hello's worldexample
 [33m[stage-5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m$ cat "/tmp/bar/f 58" "/tmp/bar/f   73" "/tmp/bar/f's38"
 [33m[your-program] [0morange blueberry.grape pineapple.raspberry mango.


### PR DESCRIPTION
**Context**:
https://forum.codecrafters.io/t/missing-single-and-double-quote-tests-for-build-your-own-shell-c-c/11319

> I think a test is missing in the test suite.
> 
> Ex: echo hello’'world
> Ex: echo hello""world
> 
> My ZSH shell outputs helloworld for both of the above examples. However, my custom shell, which is passing all of the single and double quote tests, outputs hello’'world and hello""world respectively.


**Fixture**:

<img width="769" alt="image" src="https://github.com/user-attachments/assets/147623b7-e20e-4d5c-947d-ed9eb3a9c62e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated test cases to improve accuracy of shell quoting and string concatenation scenarios. Output expectations were adjusted to reflect more complex combinations of quoted and unquoted arguments.
- **Tests**
  - Enhanced test scripts by adding new cases that cover additional concatenation patterns in shell commands, ensuring more comprehensive validation of quoting behavior.
  - Extended test inputs and expected outputs to include additional concatenated string arguments, verifying shell quoting and concatenation behavior more thoroughly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->