### PR TITLE
Add sentinel character for empty rows in screen state

### DIFF
--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -75,6 +75,12 @@ func (vt *VirtualTerminal) GetScreenState() [][]string {
 				screenState[i][j] = c.Content
 			}
 		}
+		// If there is an empty row somewhere in the middle,
+		// artificially add a sentinel character
+		emptyRowRepresentation := strings.Repeat(" ", vt.cols)
+		if i < cursorRow && strings.Join(screenState[i], "") == emptyRowRepresentation {
+			screenState[i][0] = utils.VT_SENTINEL_CHARACTER
+		}
 	}
 	return screenState
 }


### PR DESCRIPTION
Introduce a sentinel character for empty rows in the screen state to improve representation and handling of such rows.