### PR TITLE
Use screen_state package

### DIFF
--- a/internal/assertion_collection/assertion_collection.go
+++ b/internal/assertion_collection/assertion_collection.go
@@ -2,6 +2,7 @@ package assertion_collection
 
 import (
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 	"github.com/codecrafters-io/shell-tester/internal/utils"
 )
 
@@ -29,26 +30,26 @@ func (c *AssertionCollection) PopAssertion() assertions.Assertion {
 	return lastAssertion
 }
 
-func (c *AssertionCollection) RunWithPromptAssertion(screenState [][]string) *assertions.AssertionError {
+func (c *AssertionCollection) RunWithPromptAssertion(screenState screen_state.ScreenState) *assertions.AssertionError {
 	return c.runWithExtraAssertions(screenState, []assertions.Assertion{
 		assertions.PromptAssertion{ExpectedPrompt: utils.PROMPT},
 	})
 }
 
-func (c *AssertionCollection) RunWithoutPromptAssertion(screenState [][]string) *assertions.AssertionError {
+func (c *AssertionCollection) RunWithoutPromptAssertion(screenState screen_state.ScreenState) *assertions.AssertionError {
 	return c.runWithExtraAssertions(screenState, nil)
 }
 
-func (c *AssertionCollection) runWithExtraAssertions(screenState [][]string, extraAssertions []assertions.Assertion) *assertions.AssertionError {
+func (c *AssertionCollection) runWithExtraAssertions(screenState screen_state.ScreenState, extraAssertions []assertions.Assertion) *assertions.AssertionError {
 	allAssertions := append(c.Assertions, extraAssertions...)
 	currentRowIndex := 0
 
 	for _, assertion := range allAssertions {
-		if len(screenState) == 0 {
+		if screenState.GetRowCount() == 0 {
 			panic("CodeCrafters internal error: expected screen to have at least one row, but it was empty")
 		}
 
-		if currentRowIndex >= len(screenState) {
+		if currentRowIndex > screenState.GetRowCount()-1 {
 			panic("CodeCrafters internal error: startRowIndex is larger than screenState rows")
 		}
 

--- a/internal/assertions/assertion.go
+++ b/internal/assertions/assertion.go
@@ -1,6 +1,8 @@
 package assertions
 
+import "github.com/codecrafters-io/shell-tester/internal/screen_state"
+
 type Assertion interface {
-	Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError)
+	Run(screenState screen_state.ScreenState, startRowIndex int) (processedRowCount int, err *AssertionError)
 	Inspect() string
 }

--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -1,5 +1,7 @@
 package assertions
 
+import "github.com/codecrafters-io/shell-tester/internal/screen_state"
+
 // BellAssertion asserts that the bell callback function is called
 // by the virtual terminal, this can only happen if the user sends
 // /U0007 to the shell.
@@ -12,7 +14,7 @@ func (a BellAssertion) Inspect() string {
 	return "BellAssertion"
 }
 
-func (a BellAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+func (a BellAssertion) Run(screenState screen_state.ScreenState, startRowIndex int) (processedRowCount int, err *AssertionError) {
 	if checkIfBellReceived(a.BellChannel) {
 		return 0, nil
 	}

--- a/internal/assertions/file_content_assertion.go
+++ b/internal/assertions/file_content_assertion.go
@@ -3,6 +3,8 @@ package assertions
 import (
 	"fmt"
 	"os"
+
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 )
 
 // FileContentAssertion verifies a prompt exists, and that there's no extra output after it.
@@ -18,7 +20,7 @@ func (t FileContentAssertion) Inspect() string {
 	return fmt.Sprintf("FileContentAssertion (%q) with expected content (%q)", t.FilePath, t.ExpectedContent)
 }
 
-func (t FileContentAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+func (t FileContentAssertion) Run(screenState screen_state.ScreenState, startRowIndex int) (processedRowCount int, err *AssertionError) {
 	// We don't want to count the processed prompt as a complete row
 	processedRowCount = 0
 

--- a/internal/assertions/multi_line_assertion.go
+++ b/internal/assertions/multi_line_assertion.go
@@ -3,6 +3,8 @@ package assertions
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 )
 
 // MultiLineAssertion asserts that multiple lines of output matches against a given array of strings
@@ -45,7 +47,7 @@ func (a *MultiLineAssertion) Inspect() string {
 	return fmt.Sprintf("MultiLineAssertion (%v)", a.SingleLineAssertions)
 }
 
-func (a *MultiLineAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+func (a *MultiLineAssertion) Run(screenState screen_state.ScreenState, startRowIndex int) (processedRowCount int, err *AssertionError) {
 	totalProcessedRowCount := 0
 
 	for _, singleLineAssertion := range a.SingleLineAssertions {

--- a/internal/assertions/prompt_assertion.go
+++ b/internal/assertions/prompt_assertion.go
@@ -21,13 +21,13 @@ func (t PromptAssertion) Run(screenState screen_state.ScreenState, startRowIndex
 	// We don't want to count the processed prompt as a complete row
 	processedRowCount = 0
 
-	rowString := screenState.GetRow(startRowIndex).String()
+	rowAsString := screenState.GetRow(startRowIndex).String()
 
-	if !strings.EqualFold(rowString, t.ExpectedPrompt) {
+	if !strings.EqualFold(rowAsString, t.ExpectedPrompt) {
 		return processedRowCount, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
-			Message:       fmt.Sprintf("Expected prompt (%q) but received %q", t.ExpectedPrompt, rowString),
+			Message:       fmt.Sprintf("Expected prompt (%q) but received %q", t.ExpectedPrompt, rowAsString),
 		}
 	}
 

--- a/internal/assertions/prompt_assertion.go
+++ b/internal/assertions/prompt_assertion.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 )
 
 // PromptAssertion verifies a prompt exists, and that there's no extra output after it.
@@ -17,18 +17,17 @@ func (t PromptAssertion) Inspect() string {
 	return fmt.Sprintf("PromptAssertion (%q)", t.ExpectedPrompt)
 }
 
-func (t PromptAssertion) Run(screenState [][]string, startRowIndex int) (processedRowCount int, err *AssertionError) {
+func (t PromptAssertion) Run(screenState screen_state.ScreenState, startRowIndex int) (processedRowCount int, err *AssertionError) {
 	// We don't want to count the processed prompt as a complete row
 	processedRowCount = 0
 
-	rawRow := screenState[startRowIndex] // Could be nil?
-	cleanedRow := virtual_terminal.BuildCleanedRow(rawRow)
+	rowString := screenState.GetRow(startRowIndex).String()
 
-	if !strings.EqualFold(cleanedRow, t.ExpectedPrompt) {
+	if !strings.EqualFold(rowString, t.ExpectedPrompt) {
 		return processedRowCount, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
-			Message:       fmt.Sprintf("Expected prompt (%q) but received %q", t.ExpectedPrompt, cleanedRow),
+			Message:       fmt.Sprintf("Expected prompt (%q) but received %q", t.ExpectedPrompt, rowString),
 		}
 	}
 

--- a/internal/assertions/single_line_assertion.go
+++ b/internal/assertions/single_line_assertion.go
@@ -36,16 +36,16 @@ func (a SingleLineAssertion) Run(screenState screen_state.ScreenState, startRowI
 		processedRowCount = 0
 	}
 
-	rowString := screenState.GetRow(startRowIndex).String()
+	rowAsString := screenState.GetRow(startRowIndex).String()
 
 	for _, pattern := range a.FallbackPatterns {
-		if pattern.Match([]byte(rowString)) {
+		if pattern.Match([]byte(rowAsString)) {
 			return processedRowCount, nil
 		}
 	}
 
-	if rowString != a.ExpectedOutput {
-		detailedErrorMessage := utils.BuildColoredErrorMessage(a.ExpectedOutput, rowString)
+	if rowAsString != a.ExpectedOutput {
+		detailedErrorMessage := utils.BuildColoredErrorMessage(a.ExpectedOutput, rowAsString)
 		return 0, &AssertionError{
 			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -2,7 +2,6 @@ package logged_shell_asserter
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertion_collection"
@@ -117,7 +116,7 @@ func (a *LoggedShellAsserter) LogRemainingOutput() {
 }
 
 func (a *LoggedShellAsserter) logRowsUntilAndIncluding(endRowIndex int) {
-	endRowIndex = int(math.Min(float64(endRowIndex), float64(a.Shell.GetScreenState().GetLastLoggableRowIndex())))
+	endRowIndex = min(endRowIndex, a.Shell.GetScreenState().GetLastLoggableRowIndex())
 
 	for i := a.lastLoggedRowIndex + 1; i <= endRowIndex; i++ {
 		row := a.Shell.GetScreenState().GetRow(i)

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -103,7 +103,7 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Durati
 
 func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRowCount int) {
 	if processedRowCount > 0 {
-		a.logRowsUntilAndIncluding(startRowIndex + processedRowCount)
+		a.logRowsUntilAndIncluding(startRowIndex + processedRowCount - 1)
 	}
 }
 

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -102,7 +102,9 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Durati
 }
 
 func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRowCount int) {
-	a.logRowsUntilAndIncluding(startRowIndex + processedRowCount)
+	if processedRowCount > 0 {
+		a.logRowsUntilAndIncluding(startRowIndex + processedRowCount)
+	}
 }
 
 func (a *LoggedShellAsserter) logAssertionError(err assertions.AssertionError) {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -2,6 +2,7 @@ package logged_shell_asserter
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertion_collection"
@@ -118,6 +119,8 @@ func (a *LoggedShellAsserter) LogRemainingOutput() {
 }
 
 func (a *LoggedShellAsserter) logRowsUntilAndIncluding(endRowIndex int) {
+	endRowIndex = int(math.Min(float64(endRowIndex), float64(a.Shell.GetScreenState().GetLastLoggableRowIndex())))
+
 	for i := a.lastLoggedRowIndex + 1; i <= endRowIndex; i++ {
 		row := a.Shell.GetScreenState().GetRow(i)
 		a.Shell.LogOutput([]byte(row.String()))

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -103,9 +103,7 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Durati
 }
 
 func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRowCount int) {
-	if processedRowCount > 0 {
-		a.logRowsUntilAndIncluding(startRowIndex + processedRowCount - 1)
-	}
+	a.logRowsUntilAndIncluding(startRowIndex + processedRowCount - 1)
 }
 
 func (a *LoggedShellAsserter) logAssertionError(err assertions.AssertionError) {

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/assertion_collection"
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
-	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 )
 
 // INITIAL_READ_TIMEOUT is used for the first prompt read, where we want
@@ -103,38 +102,24 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Durati
 }
 
 func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRowCount int) {
-	if processedRowCount == 0 || startRowIndex <= a.lastLoggedRowIndex {
-		return
-	}
-
-	for i := 0; i < processedRowCount; i++ {
-		row := a.Shell.GetScreenState()[a.lastLoggedRowIndex+i+1]
-		a.Shell.LogOutput([]byte(virtual_terminal.BuildCleanedRow(row)))
-	}
-
-	a.lastLoggedRowIndex += processedRowCount
+	a.logRowsUntilAndIncluding(startRowIndex + processedRowCount)
 }
 
 func (a *LoggedShellAsserter) logAssertionError(err assertions.AssertionError) {
-	a.logRows(a.lastLoggedRowIndex+1, err.ErrorRowIndex)
+	a.logRowsUntilAndIncluding(err.ErrorRowIndex)
 	a.Shell.GetLogger().Errorf("%s", err.Message)
-	a.logRows(err.ErrorRowIndex+1, len(a.Shell.GetScreenState())-1)
+	a.LogRemainingOutput()
 }
 
 func (a *LoggedShellAsserter) LogRemainingOutput() {
-	startRowIndex := a.lastLoggedRowIndex + 1
-	endRowIndex := len(a.Shell.GetScreenState()) - 1
-	a.logRows(startRowIndex, endRowIndex)
-	a.lastLoggedRowIndex = endRowIndex
+	a.logRowsUntilAndIncluding(a.Shell.GetScreenState().GetLastLoggableRowIndex())
 }
 
-func (a *LoggedShellAsserter) logRows(startRowIndex int, endRowIndex int) {
-	for i := startRowIndex; i <= endRowIndex; i++ {
-		rawRow := a.Shell.GetScreenState()[i]
-		cleanedRow := virtual_terminal.BuildCleanedRow(rawRow)
-		if len(cleanedRow) > 0 {
-			a.Shell.LogOutput([]byte(cleanedRow))
-		}
+func (a *LoggedShellAsserter) logRowsUntilAndIncluding(endRowIndex int) {
+	for i := a.lastLoggedRowIndex + 1; i <= endRowIndex; i++ {
+		row := a.Shell.GetScreenState().GetRow(i)
+		a.Shell.LogOutput([]byte(row.String()))
+		a.lastLoggedRowIndex = i
 	}
 }
 

--- a/internal/screen_state/row.go
+++ b/internal/screen_state/row.go
@@ -11,6 +11,10 @@ func (r Row) HasCursor() bool {
 	return r.cursorCellIndex != -1
 }
 
+func (r Row) IsEmpty() bool {
+	return r.String() == ""
+}
+
 func (r Row) String() string {
 	if r.HasCursor() {
 		// If the cursor is on the line, we need to preserve the spaces before the cursor
@@ -22,8 +26,4 @@ func (r Row) String() string {
 		// If the cursor isn't on the line, we can safely trim spaces from the right
 		return strings.TrimRight(strings.Join(r.rawCells, ""), " ")
 	}
-}
-
-func (r Row) IsEmpty() bool {
-	return r.String() == ""
 }

--- a/internal/screen_state/row.go
+++ b/internal/screen_state/row.go
@@ -1,0 +1,29 @@
+package screen_state
+
+import "strings"
+
+type Row struct {
+	rawCells        []string
+	cursorCellIndex int
+}
+
+func (r Row) HasCursor() bool {
+	return r.cursorCellIndex != -1
+}
+
+func (r Row) String() string {
+	if r.HasCursor() {
+		// If the cursor is on the line, we need to preserve the spaces before the cursor
+		contentsBeforeCursor := strings.Join(r.rawCells[:r.cursorCellIndex], "")
+		contentsAfterCursor := strings.TrimRight(strings.Join(r.rawCells[r.cursorCellIndex:], ""), " ")
+
+		return contentsBeforeCursor + contentsAfterCursor
+	} else {
+		// If the cursor isn't on the line, we can safely trim spaces from the right
+		return strings.TrimRight(strings.Join(r.rawCells, ""), " ")
+	}
+}
+
+func (r Row) IsEmpty() bool {
+	return r.String() == ""
+}

--- a/internal/screen_state/row.go
+++ b/internal/screen_state/row.go
@@ -4,7 +4,7 @@ import "strings"
 
 type Row struct {
 	rawCells        []string
-	cursorCellIndex int
+	cursorCellIndex int // cursorCellIndex will be -1 if the cursor is not on the line
 }
 
 func (r Row) HasCursor() bool {

--- a/internal/screen_state/screen_state.go
+++ b/internal/screen_state/screen_state.go
@@ -1,7 +1,5 @@
 package screen_state
 
-import "math"
-
 type CursorPosition struct {
 	RowIndex    int
 	ColumnIndex int
@@ -53,5 +51,5 @@ func (s ScreenState) GetLastLoggableRowIndex() int {
 		}
 	}
 
-	return int(math.Max(float64(s.cursorPosition.RowIndex-1), float64(lastNonEmptyRowIndex)))
+	return max(s.cursorPosition.RowIndex-1, lastNonEmptyRowIndex)
 }

--- a/internal/screen_state/screen_state.go
+++ b/internal/screen_state/screen_state.go
@@ -1,0 +1,57 @@
+package screen_state
+
+import "math"
+
+type CursorPosition struct {
+	RowIndex    int
+	ColumnIndex int
+}
+
+// ScreenState is a representation of the screen state at a given point in time
+type ScreenState struct {
+	// rawCellMatrix is always of size [rows x cols].
+	//
+	// Empty cells are represented by " " (space)
+	rawCellMatrix [][]string
+
+	cursorPosition CursorPosition
+}
+
+func NewScreenState(rawCellMatrix [][]string, cursorPosition CursorPosition) ScreenState {
+	return ScreenState{
+		rawCellMatrix:  rawCellMatrix,
+		cursorPosition: cursorPosition,
+	}
+}
+
+func (s ScreenState) GetRow(rowIndex int) Row {
+	cursorCellIndex := -1
+
+	if s.cursorPosition.RowIndex == rowIndex {
+		cursorCellIndex = s.cursorPosition.ColumnIndex
+	}
+
+	return Row{
+		rawCells:        s.rawCellMatrix[rowIndex],
+		cursorCellIndex: cursorCellIndex,
+	}
+}
+
+func (s ScreenState) GetRowCount() int {
+	return len(s.rawCellMatrix)
+}
+
+// GetLastLoggableRowIndex returns the index of the last "loggable" row.
+//
+// This is usually the last non-empty row, but if the cursor is further ahead, it will be the row before the cursor.
+func (s ScreenState) GetLastLoggableRowIndex() int {
+	lastNonEmptyRowIndex := -1
+
+	for i := 0; i < s.GetRowCount(); i++ {
+		if !s.GetRow(i).IsEmpty() {
+			lastNonEmptyRowIndex = i
+		}
+	}
+
+	return int(math.Max(float64(s.cursorPosition.RowIndex-1), float64(lastNonEmptyRowIndex)))
+}

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/condition_reader"
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 	"github.com/codecrafters-io/shell-tester/internal/utils"
 	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 	"github.com/codecrafters-io/tester-utils/executable"
@@ -93,7 +94,7 @@ func (b *ShellExecutable) Start(args ...string) error {
 	return nil
 }
 
-func (b *ShellExecutable) GetScreenState() [][]string {
+func (b *ShellExecutable) GetScreenState() screen_state.ScreenState {
 	return b.vt.GetScreenState()
 }
 

--- a/internal/test_cases/exit_test_case.go
+++ b/internal/test_cases/exit_test_case.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/utils"
-	virtual_terminal "github.com/codecrafters-io/shell-tester/internal/vt"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
@@ -42,7 +41,7 @@ func (t ExitTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, s
 		return asserter.AssertionCollection.RunWithPromptAssertion(shell.GetScreenState())
 	}
 	readErr := shell.ReadUntilConditionOrTimeout(utils.AsBool(assertFn), logged_shell_asserter.SUBSEQUENT_READ_TIMEOUT)
-	output := virtual_terminal.BuildCleanedRow(shell.GetScreenState()[asserter.GetLastLoggedRowIndex()+1])
+	output := shell.GetScreenState().GetRow(asserter.GetLastLoggedRowIndex() + 1).String()
 
 	asserter.LogRemainingOutput()
 

--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -76,20 +76,3 @@ func (vt *VirtualTerminal) GetColumnCount() int {
 func (vt *VirtualTerminal) GetRowCount() int {
 	return vt.rows
 }
-
-func (vt *VirtualTerminal) GetRow(row int) []string {
-	screenState := make([]string, vt.cols)
-	for j := 0; j < vt.cols; j++ {
-		c := vt.vt.Cell(j, row)
-		screenState[j] = c.Content
-	}
-	return screenState
-}
-
-func (vt *VirtualTerminal) GetRowsTillEnd(startingRow int) [][]string {
-	screenState := make([][]string, vt.rows)
-	for i := startingRow; i < vt.rows; i++ {
-		screenState[i] = vt.GetRow(i)
-	}
-	return screenState
-}

--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -54,10 +54,6 @@ func (vt *VirtualTerminal) Write(p []byte) (n int, err error) {
 }
 
 func (vt *VirtualTerminal) GetScreenState() screen_state.ScreenState {
-	if vt == nil {
-		return screen_state.ScreenState{}
-	}
-
 	cellMatrix := make([][]string, vt.rows)
 
 	for i := 0; i < vt.rows; i++ {

--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -58,11 +58,6 @@ func (vt *VirtualTerminal) GetScreenState() screen_state.ScreenState {
 		return screen_state.ScreenState{}
 	}
 
-	cursorPosition := screen_state.CursorPosition{
-		RowIndex:    vt.vt.CursorPosition().Y,
-		ColumnIndex: vt.vt.CursorPosition().X,
-	}
-
 	cellMatrix := make([][]string, vt.rows)
 
 	for i := 0; i < vt.rows; i++ {
@@ -72,7 +67,10 @@ func (vt *VirtualTerminal) GetScreenState() screen_state.ScreenState {
 		}
 	}
 
-	return screen_state.NewScreenState(cellMatrix, cursorPosition)
+	return screen_state.NewScreenState(cellMatrix, screen_state.CursorPosition{
+		RowIndex:    vt.vt.CursorPosition().Y,
+		ColumnIndex: vt.vt.CursorPosition().X,
+	})
 }
 
 func (vt *VirtualTerminal) GetColumnCount() int {

--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -1,10 +1,8 @@
 package virtual_terminal
 
 import (
-	"strings"
-
 	"github.com/charmbracelet/x/vt"
-	"github.com/codecrafters-io/shell-tester/internal/utils"
+	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 )
 
 type VirtualTerminal struct {
@@ -55,28 +53,26 @@ func (vt *VirtualTerminal) Write(p []byte) (n int, err error) {
 	return vt.vt.Write(p)
 }
 
-func (vt *VirtualTerminal) GetScreenState() [][]string {
+func (vt *VirtualTerminal) GetScreenState() screen_state.ScreenState {
 	if vt == nil {
-		return [][]string{}
+		return screen_state.ScreenState{}
 	}
-	cursorPosition := vt.vt.CursorPosition()
-	cursorRow, cursorCol := cursorPosition.Y, cursorPosition.X
 
-	// For the row where the cursor is present
-	// We intend to keep all characters upto the cursor position
-	screenState := make([][]string, vt.rows)
+	cursorPosition := screen_state.CursorPosition{
+		RowIndex:    vt.vt.CursorPosition().Y,
+		ColumnIndex: vt.vt.CursorPosition().X,
+	}
+
+	cellMatrix := make([][]string, vt.rows)
+
 	for i := 0; i < vt.rows; i++ {
-		screenState[i] = make([]string, vt.cols)
+		cellMatrix[i] = make([]string, vt.cols)
 		for j := 0; j < vt.cols; j++ {
-			c := vt.vt.Cell(j, i)
-			if i == cursorRow && j < cursorCol && c.Content == " " {
-				screenState[i][j] = utils.VT_SENTINEL_CHARACTER
-			} else {
-				screenState[i][j] = c.Content
-			}
+			cellMatrix[i][j] = vt.vt.Cell(j, i).Content
 		}
 	}
-	return screenState
+
+	return screen_state.NewScreenState(cellMatrix, cursorPosition)
 }
 
 func (vt *VirtualTerminal) GetColumnCount() int {
@@ -102,13 +98,4 @@ func (vt *VirtualTerminal) GetRowsTillEnd(startingRow int) [][]string {
 		screenState[i] = vt.GetRow(i)
 	}
 	return screenState
-}
-
-func BuildCleanedRow(row []string) string {
-	result := strings.Join(row, "")
-	result = strings.TrimRight(result, " ")
-
-	// VT_SENTINEL_CHARACTER is the representation of " " that we intend to preserve
-	result = strings.ReplaceAll(result, utils.VT_SENTINEL_CHARACTER, " ")
-	return result
 }


### PR DESCRIPTION
This removes the usage of VT_SENTINEL and instead returns a `ScreenState` data structure. 

It also removes the need to filter out empty rows when logging, instead relies on function that calculates the last "loggable" row. 