### PR TITLE
Update GitHub token for fixture generation in workflow

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RYAN_FIXTURE_GEN_PAT }}
+          token: ${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v1
@@ -37,13 +37,13 @@ jobs:
           labels: regenerate-fixtures
 
       - name: Regenerate Fixtures
-        run: CODECRAFTERS_RECORD_FIXTURES=true make test 
+        run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures
         run: |
           git config --global user.email "ryan-gg@outlook.com"
           git config --global user.name "Ryan Gang"
-          git remote set-url origin https://ryan-gang:${{ secrets.RYAN_FIXTURE_GEN_PAT }}@github.com/codecrafters-io/shell-tester.git
+          git remote set-url origin https://ryan-gang:${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}@github.com/codecrafters-io/shell-tester.git
           git fetch origin ${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
           git diff --quiet || (git add . && git commit -m "ci: add regenerated fixtures" && git push)


### PR DESCRIPTION
Replace the GitHub token used for fixture generation in the workflow to ensure proper access and functionality.