### PR TITLE
Refactor assertion error struct 

### DIFF
--- a/internal/assertions/assertion_error.go
+++ b/internal/assertions/assertion_error.go
@@ -1,17 +1,12 @@
 package assertions
 
 type AssertionError struct {
-	ErrorRowIndex int // Will be -1 if the error doesn't affect a specific line range (e.g. bell)
+	ErrorRowIndex int // Will be -1 if the error doesn't affect a specific line
 	Message       string
-	StartRowIndex int // Will be -1 if the error doesn't affect a specific line range (e.g. bell)
 }
 
-func (e AssertionError) AffectsLineRange() bool {
-	return e.ErrorRowIndex != -1 && e.StartRowIndex != -1
-}
-
-func (e AssertionError) AffectsSingleLine() bool {
-	return e.AffectsLineRange() && e.StartRowIndex == e.ErrorRowIndex
+func (e AssertionError) AffectsLine() bool {
+	return e.ErrorRowIndex != -1
 }
 
 func (e AssertionError) Error() string {

--- a/internal/assertions/bell_assertion.go
+++ b/internal/assertions/bell_assertion.go
@@ -19,7 +19,6 @@ func (a BellAssertion) Run(screenState screen_state.ScreenState, startRowIndex i
 		return 0, nil
 	}
 	return 0, &AssertionError{
-		StartRowIndex: -1,
 		ErrorRowIndex: -1,
 		Message:       "Expected bell to ring, but it didn't",
 	}

--- a/internal/assertions/file_content_assertion.go
+++ b/internal/assertions/file_content_assertion.go
@@ -27,7 +27,6 @@ func (t FileContentAssertion) Run(screenState screen_state.ScreenState, startRow
 	fileContent, readErr := os.ReadFile(t.FilePath)
 	if readErr != nil {
 		return processedRowCount, &AssertionError{
-			StartRowIndex: -1,
 			ErrorRowIndex: -1,
 			Message:       fmt.Sprintf("Expected file %q to exist. Error: %v", t.FilePath, readErr),
 		}
@@ -35,7 +34,6 @@ func (t FileContentAssertion) Run(screenState screen_state.ScreenState, startRow
 
 	if string(fileContent) != t.ExpectedContent {
 		return processedRowCount, &AssertionError{
-			StartRowIndex: -1,
 			ErrorRowIndex: -1,
 			Message:       fmt.Sprintf("Expected %s to contain %q but received %q", t.FilePath, t.ExpectedContent, fileContent),
 		}

--- a/internal/assertions/prompt_assertion.go
+++ b/internal/assertions/prompt_assertion.go
@@ -25,7 +25,6 @@ func (t PromptAssertion) Run(screenState screen_state.ScreenState, startRowIndex
 
 	if !strings.EqualFold(rowString, t.ExpectedPrompt) {
 		return processedRowCount, &AssertionError{
-			StartRowIndex: startRowIndex,
 			ErrorRowIndex: startRowIndex,
 			Message:       fmt.Sprintf("Expected prompt (%q) but received %q", t.ExpectedPrompt, rowString),
 		}

--- a/internal/assertions/single_line_assertion.go
+++ b/internal/assertions/single_line_assertion.go
@@ -59,13 +59,11 @@ func (a SingleLineAssertion) Run(screenState screen_state.ScreenState, startRowI
 		// If the line won't be logged, we say "didn't find line ..." instead of "line does not match expected ..."
 		if startRowIndex > screenState.GetLastLoggableRowIndex() {
 			return 0, &AssertionError{
-				StartRowIndex: startRowIndex,
 				ErrorRowIndex: startRowIndex,
 				Message:       "Didn't find expected line.\n" + detailedErrorMessage,
 			}
 		} else {
 			return 0, &AssertionError{
-				StartRowIndex: startRowIndex,
 				ErrorRowIndex: startRowIndex,
 				Message:       "Line does not match expected value.\n" + detailedErrorMessage,
 			}

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -106,12 +106,12 @@ func (a *LoggedShellAsserter) onAssertionSuccess(startRowIndex int, processedRow
 }
 
 func (a *LoggedShellAsserter) logAssertionError(err assertions.AssertionError) {
-	if err.AffectsLineRange() {
+	if err.AffectsLine() {
 		a.logRowsUntilAndIncluding(err.ErrorRowIndex)
 	}
 
 	// If we did log the errored line, let's point to it with a caret
-	if err.AffectsSingleLine() && err.ErrorRowIndex == a.lastLoggedRowIndex {
+	if err.AffectsLine() && err.ErrorRowIndex == a.lastLoggedRowIndex {
 		a.Shell.GetLogger().Errorf("^ %s", err.Message)
 	} else {
 		a.Shell.GetLogger().Errorf("%s", err.Message)

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -179,7 +179,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 	replacements := map[string][]*regexp.Regexp{
 		"/bin/$1":                         {regexp.MustCompile(`\/usr/bin/(\w+)`)},
 		"[your-program] my_exe is <path>": {regexp.MustCompile(`\[your-program\] .{4}my_exe is .*`)},
-		"[your-program] <cwd>":            {regexp.MustCompile(`\[your-program\] .{4}/(workspaces|home|Users|app)/.*`)},
+		"[your-program] <cwd>":            {regexp.MustCompile(`\[your-program\] .{0,4}/(workspace|workspaces|home|Users|app)/.*`)},
 		"ls-la-output-line":               {regexp.MustCompile(`-rw-r--r-- .*`)},
 		"PATH is now: <path>":             {regexp.MustCompile(`PATH is now: .*`)},
 		"/tmp/":                           {regexp.MustCompile(`/var/folders/.*/.*/.*/`)},


### PR DESCRIPTION
Simplify assertion error checks by removing `StartRowIndex` and streamlining line range checks.