### PR TITLE
Fix Non sequential numbers passing the history tester command

### DIFF
--- a/internal/stage_h3.go
+++ b/internal/stage_h3.go
@@ -43,8 +43,9 @@ func testH3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase1 := test_cases.HistoryTestCase{
-		PreviousCommands: previousCommands,
+		HistoryOffset:    0, // These are the first commands in history
 		LastNCommands:    2,
+		PreviousCommands: previousCommands,
 		SuccessMessage:   "✓ Received expected response",
 	}
 	if err := testCase1.Run(asserter, shell, logger); err != nil {
@@ -79,8 +80,9 @@ func testH3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase2 := test_cases.HistoryTestCase{
-		PreviousCommands: previousCommands,
+		HistoryOffset:    4, // 3 initial commands + 1 history command
 		LastNCommands:    random.RandomInt(3, 5),
+		PreviousCommands: previousCommands,
 		SuccessMessage:   "✓ Received expected response",
 	}
 	if err := testCase2.Run(asserter, shell, logger); err != nil {

--- a/internal/test_cases/history_test_case.go
+++ b/internal/test_cases/history_test_case.go
@@ -57,6 +57,7 @@ func (t HistoryTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter
 			ExpectedOutput: fmt.Sprintf("    %d  %s", expectedLineNumber, command),
 			FallbackPatterns: []*regexp.Regexp{
 				regexp.MustCompile(fmt.Sprintf(`^\s*%d\s+%s$`, expectedLineNumber, regexp.QuoteMeta(command))),
+				regexp.MustCompile(fmt.Sprintf(`^\s*%d\s+%s$`, expectedLineNumber-1, regexp.QuoteMeta(command))), // 0-based for ash
 			},
 		})
 	}
@@ -67,6 +68,7 @@ func (t HistoryTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter
 		ExpectedOutput: fmt.Sprintf("    %d  %s", expectedHistoryLineNumber, historyCommand),
 		FallbackPatterns: []*regexp.Regexp{
 			regexp.MustCompile(fmt.Sprintf(`^\s*%d\s+%s$`, expectedHistoryLineNumber, regexp.QuoteMeta(historyCommand))),
+			regexp.MustCompile(fmt.Sprintf(`^\s*%d\s+%s$`, expectedHistoryLineNumber-1, regexp.QuoteMeta(historyCommand))), // 0-based for ash
 		},
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced history test cases to support customizable starting line numbers in command history outputs.

* **Bug Fixes**
  * Improved accuracy of test assertions for history outputs by accounting for line number offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->