### PR TITLE
Trying to remove the `$ ` failure from Shell Challenge Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run tests against all shells on alpine
         run: |
-          make test_zsh
+          script -q -c "make test_zsh" /dev/null
         shell: bash
 
   test-alpine:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to modify how zsh tests are executed, resulting in quieter test output during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->