### PR TITLE
Remove "Assertion failed." error message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ toolchain go1.24.2
 
 require (
 	github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d
-	github.com/codecrafters-io/tester-utils v0.4.15
+	github.com/codecrafters-io/tester-utils v0.4.17
 	github.com/creack/pty v1.1.24
 	github.com/fatih/color v1.18.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/stretchr/testify v1.10.0
 	go.chromium.org/luci v0.0.0-20250611085002-a5741c865576
 )
 
@@ -29,7 +30,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d h1:cIxw4y+aEGux
 github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d/go.mod h1:RB6f81fnGXyFGRenuO1fMdTlBh0Dbp/0+jwiMtgZvJw=
 github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91 h1:D5OO0lVavz7A+Swdhp62F9gbkibxmz9B2hZ/jVdMPf0=
 github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91/go.mod h1:Ey8PFmYwH+/td9bpiEx07Fdx9ZVkxfIjWXxBluxF4Nw=
-github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/gLbrqvylwD2oDlc=
-github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.17 h1:1vpkUOGfvKNOeokL9UiIA4O7zQljT5KDG78dTzm2ojM=
+github.com/codecrafters-io/tester-utils v0.4.17/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/logged_shell_asserter/logged_shell_asserter.go
+++ b/internal/logged_shell_asserter/logged_shell_asserter.go
@@ -1,7 +1,7 @@
 package logged_shell_asserter
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertion_collection"
@@ -97,7 +97,7 @@ func (a *LoggedShellAsserter) assert(withoutPrompt bool, readTimeout time.Durati
 		}
 		if assertionErr := assertFn(); assertionErr != nil {
 			a.logAssertionError(*assertionErr)
-			return fmt.Errorf("Assertion failed.")
+			return errors.New("")
 		}
 	}
 

--- a/internal/test_helpers/fixtures/no_output
+++ b/internal/test_helpers/fixtures/no_output
@@ -6,5 +6,4 @@ Debug = true
 [33m[tester::#CZ2] [0m[91mDidn't find expected line.[0m
 [33m[tester::#CZ2] [0m[91m[32mExpected:[0m "invalid_apple_command: command not found"[0m
 [33m[tester::#CZ2] [0m[91m[31mReceived:[0m "" [31m(no line received)[0m[0m
-[33m[tester::#CZ2] [0m[91m[0m
 [33m[tester::#CZ2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/no_output
+++ b/internal/test_helpers/fixtures/no_output
@@ -6,5 +6,5 @@ Debug = true
 [33m[tester::#CZ2] [0m[91mDidn't find expected line.[0m
 [33m[tester::#CZ2] [0m[91m[32mExpected:[0m "invalid_apple_command: command not found"[0m
 [33m[tester::#CZ2] [0m[91m[31mReceived:[0m "" [31m(no line received)[0m[0m
-[33m[tester::#CZ2] [0m[91mAssertion failed.[0m
+[33m[tester::#CZ2] [0m[91m[0m
 [33m[tester::#CZ2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/run_program_newline_in_args
+++ b/internal/test_helpers/fixtures/run_program_newline_in_args
@@ -17,5 +17,5 @@ Debug = true
 [33m[tester::#IP1] [0m[91m[32mExpected:[0m "Program Signature: 3842155998"[0m
 [33m[tester::#IP1] [0m[91m[31mReceived:[0m "" [31m(empty line)[0m[0m
 [33m[your-program] [0m[0mProgram Signature: 3842155998[0m
-[33m[tester::#IP1] [0m[91mAssertion failed.[0m
+[33m[tester::#IP1] [0m[91m[0m
 [33m[tester::#IP1] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/run_program_newline_in_args
+++ b/internal/test_helpers/fixtures/run_program_newline_in_args
@@ -17,5 +17,4 @@ Debug = true
 [33m[tester::#IP1] [0m[91m[32mExpected:[0m "Program Signature: 3842155998"[0m
 [33m[tester::#IP1] [0m[91m[31mReceived:[0m "" [31m(empty line)[0m[0m
 [33m[your-program] [0m[0mProgram Signature: 3842155998[0m
-[33m[tester::#IP1] [0m[91m[0m
 [33m[tester::#IP1] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/wrong_output
+++ b/internal/test_helpers/fixtures/wrong_output
@@ -7,5 +7,5 @@ Debug = true
 [33m[tester::#CZ2] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#CZ2] [0m[91m[32mExpected:[0m "invalid_apple_command: command not found"[0m
 [33m[tester::#CZ2] [0m[91m[31mReceived:[0m "Command: invalid_apple_command"[0m
-[33m[tester::#CZ2] [0m[91mAssertion failed.[0m
+[33m[tester::#CZ2] [0m[91m[0m
 [33m[tester::#CZ2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/wrong_output
+++ b/internal/test_helpers/fixtures/wrong_output
@@ -7,5 +7,4 @@ Debug = true
 [33m[tester::#CZ2] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#CZ2] [0m[91m[32mExpected:[0m "invalid_apple_command: command not found"[0m
 [33m[tester::#CZ2] [0m[91m[31mReceived:[0m "Command: invalid_apple_command"[0m
-[33m[tester::#CZ2] [0m[91m[0m
 [33m[tester::#CZ2] [0m[91mTest failed[0m


### PR DESCRIPTION
New fixtures:

<img width="1694" height="1224" alt="image" src="https://github.com/user-attachments/assets/5f50566a-c252-4ee5-bdff-6f05c4c19d06" />

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to user-facing error output on assertion failures plus a small dependency bump; no core execution or security-sensitive logic is modified.
> 
> **Overview**
> Removes the generic `"Assertion failed."` message from assertion failures: `LoggedShellAsserter.assert()` now returns an empty error after logging the specific assertion details, and fixture outputs are updated accordingly.
> 
> Bumps `github.com/codecrafters-io/tester-utils` from `v0.4.15` to `v0.4.17` and promotes `github.com/stretchr/testify` to a direct dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 182bed121782d57efed85c410fdda0b8fef51c5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->