### PR TITLE
Background Jobs (Stages 7 and 8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,8 @@ define _BACKGROUND_JOBS_STAGES
 	{"slug":"dk5","tester_log_prefix":"tester::#dk5","title":"Stage#4: List multiple jobs"}, \
 	{"slug":"ma9","tester_log_prefix":"tester::#ma9","title":"Stage#5: Reaping one job using jobs"}, \
 	{"slug":"rq2","tester_log_prefix":"tester::#rq2","title":"Stage#6: Reaping multiple jobs using jobs"}, \
-	{"slug":"bv8","tester_log_prefix":"tester::#bv8","title":"Stage#6: Reap before the next prompt"}, \
-	{"slug":"fy4","tester_log_prefix":"tester::#fy4","title":"Stage#6: Job number reset"} \
+	{"slug":"bv8","tester_log_prefix":"tester::#bv8","title":"Stage#7: Reap before the next prompt"}, \
+	{"slug":"fy4","tester_log_prefix":"tester::#fy4","title":"Stage#8: Job number reset"} \
 ]
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,9 @@ define _BACKGROUND_JOBS_STAGES
 	{"slug":"jd6","tester_log_prefix":"tester::#jd6","title":"Stage#3: List a single job"}, \
 	{"slug":"dk5","tester_log_prefix":"tester::#dk5","title":"Stage#4: List multiple jobs"}, \
 	{"slug":"ma9","tester_log_prefix":"tester::#ma9","title":"Stage#5: Reaping one job using jobs"}, \
-	{"slug":"rq2","tester_log_prefix":"tester::#rq2","title":"Stage#6: Reaping multiple jobs using jobs"} \
+	{"slug":"rq2","tester_log_prefix":"tester::#rq2","title":"Stage#6: Reaping multiple jobs using jobs"}, \
+	{"slug":"bv8","tester_log_prefix":"tester::#bv8","title":"Stage#6: Reap before the next prompt"}, \
+	{"slug":"fy4","tester_log_prefix":"tester::#fy4","title":"Stage#6: Job number reset"} \
 ]
 endef
 

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d
 	github.com/codecrafters-io/tester-utils v0.4.15
 	github.com/creack/pty v1.1.24
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/stretchr/testify v1.10.0
 	go.chromium.org/luci v0.0.0-20250611085002-a5741c865576
 )
 
@@ -20,7 +22,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.7.0 // indirect
 	github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -30,7 +31,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/internal/stage_bg1.go
+++ b/internal/stage_bg1.go
@@ -27,7 +27,7 @@ func testBG1(stageHarness *test_case_harness.TestCaseHarness) error {
 	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
 		SuccessMessage: "✓ Received empty response",
 		// Expect no output
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{},
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
 	}
 
 	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -30,7 +30,7 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Assert the job output
 	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
 			JobNumber:     1,
 			Status:        "Running",
 			LaunchCommand: backgroundLaunchCommand,

--- a/internal/stage_bg4.go
+++ b/internal/stage_bg4.go
@@ -52,7 +52,7 @@ func launchBgCommandAndAssertJobs(asserter *logged_shell_asserter.LoggedShellAss
 
 		jobs = append(jobs, jobInfo{JobNumber: i + 1, Command: bgCommand})
 
-		jobsOutputEntries := make([]test_cases.JobsBuiltinOutputEntry, 0, len(jobs))
+		jobsOutputEntries := make([]test_cases.BackgroundJobStatusEntry, 0, len(jobs))
 
 		for i, job := range jobs {
 			// Default marker is unmarked
@@ -66,7 +66,7 @@ func launchBgCommandAndAssertJobs(asserter *logged_shell_asserter.LoggedShellAss
 				marker = test_cases.PreviousJob
 			}
 
-			jobsOutputEntries = append(jobsOutputEntries, test_cases.JobsBuiltinOutputEntry{
+			jobsOutputEntries = append(jobsOutputEntries, test_cases.BackgroundJobStatusEntry{
 				JobNumber:     job.JobNumber,
 				Status:        "Running",
 				LaunchCommand: job.Command,

--- a/internal/stage_bg5.go
+++ b/internal/stage_bg5.go
@@ -40,7 +40,7 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Call jobs
 	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
 			JobNumber:     1,
 			Status:        "Running",
 			LaunchCommand: bgGrepCommand,
@@ -63,7 +63,7 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Call jobs again
 	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
 			JobNumber:     1,
 			Status:        "Done",
 			LaunchCommand: bgGrepCommand,

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -73,7 +73,7 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Call jobs for the first time
 	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.UnmarkedJob},
 			{JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.PreviousJob},
 			{JobNumber: 3, Status: "Running", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
@@ -92,7 +92,7 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Call jobs for the second time
 	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
 			{JobNumber: 3, Status: "Done", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
 		},
@@ -104,7 +104,7 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Call jobs again
 	jobsBuiltinTestCase3 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob},
 		},
 		SuccessMessage: "Expected 1 entries found in the output",

--- a/internal/stage_bg7.go
+++ b/internal/stage_bg7.go
@@ -1,0 +1,100 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	// Spawn background process: sleep 500
+	sleepCommand := "sleep 500"
+	bgSleepTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}
+	if err := bgSleepTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Grep read pattern
+	grepPattern := random.RandomWord()
+	bgGrepCommand := fmt.Sprintf("grep -q %s %s", grepPattern, fifoPath)
+	bgGrepTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgGrepCommand,
+		ExpectedJobNumber: 2,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}
+	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Run jobs
+	jobsBuiltinTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Received 2 entries for the running jobs",
+	}
+	if err := jobsBuiltinTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write to fifo
+	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
+		return err
+	}
+
+	// Issue an echo command and expect the reaped job entry will follow the echoed text
+	echoArgument := random.RandomWord()
+	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
+		Command:               fmt.Sprintf("echo %s", echoArgument),
+		ExpectedCommandOutput: echoArgument,
+		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     2,
+			Status:        "Done",
+			LaunchCommand: bgGrepCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+	}
+
+	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Call jobs — only sleep (job 1) remains
+	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     1,
+			Status:        "Running",
+			LaunchCommand: sleepCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ Received 1 entry for the remaining running job",
+	}
+	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_bg7.go
+++ b/internal/stage_bg7.go
@@ -29,7 +29,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 	bgSleepTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand,
 		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}
 	if err := bgSleepTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -41,7 +41,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 	bgGrepTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand,
 		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}
 	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -53,7 +53,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
 			{JobNumber: 2, Status: "Running", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received 2 entries for the running jobs",
+		SuccessMessage: "✓ Found 2 entries for the running jobs",
 	}
 	if err := jobsBuiltinTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -75,7 +75,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 			LaunchCommand: bgGrepCommand,
 			Marker:        test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+		SuccessMessage: "✓ Found command output followed by an entry for the reaped job",
 	}
 
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
@@ -90,7 +90,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 			LaunchCommand: sleepCommand,
 			Marker:        test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ Received 1 entry for the remaining running job",
+		SuccessMessage: "✓ 1 entry matches the running job",
 	}
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stage_bg7.go
+++ b/internal/stage_bg7.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -37,7 +38,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Grep read pattern
 	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep -q %s %s", grepPattern, fifoPath)
+	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
 	bgGrepTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand,
 		ExpectedJobNumber: 2,
@@ -64,11 +65,22 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	// Background output test case
+	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand)),
+	}
+
+	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	// Issue an echo command and expect the reaped job entry will follow the echoed text
 	echoArgument := random.RandomWord()
 	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
-		Command:               fmt.Sprintf("echo %s", echoArgument),
-		ExpectedCommandOutput: echoArgument,
+		Command:                          fmt.Sprintf("echo %s", echoArgument),
+		ExpectedCommandOutput:            echoArgument,
+		ShouldSkipCurrentPromptAssertion: true,
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
 			JobNumber:     2,
 			Status:        "Done",

--- a/internal/stage_bg8.go
+++ b/internal/stage_bg8.go
@@ -1,0 +1,174 @@
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testBG8(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+
+	if err := testBg8ResetToZero(stageHarness); err != nil {
+		return err
+	}
+
+	logger.Infof("Tearing down shell")
+
+	return testBg8Recycle(stageHarness)
+}
+
+func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	logger := stageHarness.Logger
+
+	fifoPath1 := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	grepPattern1 := random.RandomWord()
+	bgGrepCommand1 := fmt.Sprintf("grep -q %s %s", grepPattern1, fifoPath1)
+	bgGrepTestCase := &test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgGrepCommand1,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}
+	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write to fifo to make job 1 'Done'
+	if err := WriteToFile(stageHarness, fifoPath1, grepPattern1); err != nil {
+		return err
+	}
+
+	time.Sleep(time.Millisecond)
+
+	echoArg := random.RandomWord()
+	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
+		Command:               fmt.Sprintf("echo %s", echoArg),
+		ExpectedCommandOutput: echoArg,
+		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+	}
+
+	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsEmptyTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
+		SuccessMessage:        "✓ Received no entries",
+	}
+
+	if err := jobsEmptyTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	sleepCommand := "sleep 10"
+	if err := (&test_cases.BackgroundCommandResponseTestCase{Command: sleepCommand, ExpectedJobNumber: 1}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsOneEntryTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ Received 1 entry for the running job",
+	}
+
+	if err := jobsOneEntryTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	logger := stageHarness.Logger
+
+	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	sleepLong := "sleep 100"
+	bgLongCmd := &test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepLong,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}
+	if err := bgLongCmd.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	grepPattern := random.RandomWord()
+	bgGrepCommand := fmt.Sprintf("grep -q %s %s", grepPattern, fifoPath)
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgGrepCommand,
+		ExpectedJobNumber: 2,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
+		return err
+	}
+	time.Sleep(time.Millisecond)
+
+	echoArgument := random.RandomWord()
+	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
+		Command:               fmt.Sprintf("echo %s", echoArgument),
+		ExpectedCommandOutput: echoArgument,
+		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
+			JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+	}
+	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	sleep50 := "sleep 50"
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleep50,
+		ExpectedJobNumber: 2,
+		SuccessMessage:    "✓ Received entry for the launched job",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsTwo := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepLong, Marker: test_cases.PreviousJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: sleep50, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Received 2 entries for the running jobs",
+	}
+
+	if err := jobsTwo.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_bg8.go
+++ b/internal/stage_bg8.go
@@ -42,7 +42,7 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 	bgGrepTestCase := &test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand1,
 		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}
 	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -55,23 +55,34 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	time.Sleep(time.Millisecond)
 
-	echoArg := random.RandomWord()
+	echoArgs := random.RandomWords(2)
 	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
-		Command:               fmt.Sprintf("echo %s", echoArg),
-		ExpectedCommandOutput: echoArg,
+		Command:               fmt.Sprintf("echo %s", echoArgs[0]),
+		ExpectedCommandOutput: echoArgs[0],
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
 	}
 
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
+	// Test command output not followed by reaped jobs entry
+	echoTestCase2 := test_cases.CommandResponseTestCase{
+		Command:        fmt.Sprintf("echo %s", echoArgs[1]),
+		ExpectedOutput: echoArgs[1],
+		SuccessMessage: "✓ Received output for echo",
+	}
+
+	if err := echoTestCase2.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	jobsEmptyTestCase := test_cases.JobsBuiltinResponseTestCase{
 		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
-		SuccessMessage:        "✓ Received no entries",
+		SuccessMessage:        "✓ No jobs",
 	}
 
 	if err := jobsEmptyTestCase.Run(asserter, shell, logger); err != nil {
@@ -82,7 +93,7 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand,
 		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Received entry for started job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
@@ -91,7 +102,7 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
 			JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ Received 1 entry for the running job",
+		SuccessMessage: "✓ 1 entry matches the running job",
 	}
 
 	if err := jobsOneEntryTestCase.Run(asserter, shell, logger); err != nil {
@@ -119,7 +130,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 	sleepCommandTestCase := &test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand,
 		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}
 	if err := sleepCommandTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -130,7 +141,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand,
 		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
@@ -147,7 +158,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
 			JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ Received command output followed by an entry for the reaped job",
+		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
 	}
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
 		return err
@@ -157,7 +168,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand2,
 		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Received entry for the launched job",
+		SuccessMessage:    "✓ Output includes job number with PID",
 	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
@@ -167,7 +178,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
 			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received 2 entries for the running jobs",
+		SuccessMessage: "✓ 2 entries match the running jobs",
 	}
 
 	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {

--- a/internal/stage_bg8.go
+++ b/internal/stage_bg8.go
@@ -79,7 +79,11 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	sleepCommand := "sleep 10"
-	if err := (&test_cases.BackgroundCommandResponseTestCase{Command: sleepCommand, ExpectedJobNumber: 1}).Run(asserter, shell, logger); err != nil {
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Received entry for started job",
+	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
@@ -111,13 +115,13 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	sleepLong := "sleep 100"
-	bgLongCmd := &test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleepLong,
+	sleepCommand := "sleep 100"
+	sleepCommandTestCase := &test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand,
 		ExpectedJobNumber: 1,
 		SuccessMessage:    "✓ Received entry for the launched job",
 	}
-	if err := bgLongCmd.Run(asserter, shell, logger); err != nil {
+	if err := sleepCommandTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
@@ -149,24 +153,24 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	sleep50 := "sleep 50"
+	sleepCommand2 := "sleep 50"
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleep50,
+		Command:           sleepCommand2,
 		ExpectedJobNumber: 2,
 		SuccessMessage:    "✓ Received entry for the launched job",
 	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	jobsTwo := test_cases.JobsBuiltinResponseTestCase{
+	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
 		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepLong, Marker: test_cases.PreviousJob},
-			{JobNumber: 2, Status: "Running", LaunchCommand: sleep50, Marker: test_cases.CurrentJob},
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.CurrentJob},
 		},
 		SuccessMessage: "✓ Received 2 entries for the running jobs",
 	}
 
-	if err := jobsTwo.Run(asserter, shell, logger); err != nil {
+	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg8.go
+++ b/internal/stage_bg8.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -38,7 +39,7 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	grepPattern1 := random.RandomWord()
-	bgGrepCommand1 := fmt.Sprintf("grep -q %s %s", grepPattern1, fifoPath1)
+	bgGrepCommand1 := fmt.Sprintf("grep %s %s", grepPattern1, fifoPath1)
 	bgGrepTestCase := &test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand1,
 		ExpectedJobNumber: 1,
@@ -55,6 +56,16 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	time.Sleep(time.Millisecond)
 
+	// Background output test case for grep
+	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern1},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand1)),
+	}
+
+	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	echoArgs := random.RandomWords(2)
 	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
 		Command:               fmt.Sprintf("echo %s", echoArgs[0]),
@@ -62,7 +73,8 @@ func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
+		ShouldSkipCurrentPromptAssertion: true,
+		SuccessMessage:                   "✓ Received output for echo followed by an entry for the reaped job",
 	}
 
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
@@ -137,7 +149,7 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep -q %s %s", grepPattern, fifoPath)
+	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand,
 		ExpectedJobNumber: 2,
@@ -151,6 +163,17 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	time.Sleep(time.Millisecond)
 
+	// Background output test case for grep
+
+	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand)),
+	}
+
+	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	echoArgument := random.RandomWord()
 	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
 		Command:               fmt.Sprintf("echo %s", echoArgument),
@@ -158,7 +181,8 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
 			JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
+		ShouldSkipCurrentPromptAssertion: true,
+		SuccessMessage:                   "✓ Received output for echo followed by an entry for the reaped job",
 	}
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stage_p1.go
+++ b/internal/stage_p1.go
@@ -78,10 +78,10 @@ func testP1(stageHarness *test_case_harness.TestCaseHarness) error {
 	input = fmt.Sprintf(`tail -f %s | head -n 5`, filePath)
 	expectedMultiLineOutput := strings.Split(strings.Trim(fileContent, "\n"), "\n")
 	multiLineTestCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:             input,
-		MultiLineAssertion:  assertions.NewMultiLineAssertion(expectedMultiLineOutput),
-		SuccessMessage:      "✓ Received redirected file content",
-		SkipPromptAssertion: true,
+		Command:                       input,
+		MultiLineAssertion:            assertions.NewMultiLineAssertion(expectedMultiLineOutput),
+		SuccessMessage:                "✓ Received redirected file content",
+		ShouldSkipNextPromptAssertion: true,
 	}
 	if err := multiLineTestCase.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -258,6 +258,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"[your-program] [JOB_NUM]PID":                {regexp.MustCompile(`\[your-program\].*\[\d+\]\d+`)},
 		"[tester::#AT7] Received: \"[JOB_NUM]PID\"":  {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\]\d+"`)},
 		"[tester::#AT7] Received: \"[JOB_NUM] PID\"": {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\] \d+"`)},
+		"[tester::#FY4] Received: \"[JOB_NUM] PID\"": {regexp.MustCompile(`\[tester::#FY4\].*Received:.*"\[\d+\] \d+"`)},
 		// For background jobs incorrect job number
 	}
 

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -139,6 +139,13 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"background_jobs_job_number_not_recycled": {
+			StageSlugs:          []string{"fy4"},
+			CodePath:            "./test_helpers/scenarios/background_jobs_job_number_not_recycled",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_job_number_not_recycled",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"pipelines_pass_bash": {
 			StageSlugs:          []string{"br6", "ny9", "xk3"},
 			CodePath:            "./test_helpers/bash",

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -98,7 +98,7 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"background_jobs_pass_bash": {
-			StageSlugs:          []string{"af3", "at7", "jd6", "dk5", "ma9", "rq2"},
+			StageSlugs:          []string{"af3", "at7", "jd6", "dk5", "ma9", "rq2", "bv8", "fy4"},
 			CodePath:            "./test_helpers/bash",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/bash/background_jobs/pass",

--- a/internal/test_cases/command_response_with_reaped_jobs_test_case.go
+++ b/internal/test_cases/command_response_with_reaped_jobs_test_case.go
@@ -1,0 +1,80 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type CommandResponseWithReapedJobsTestCase struct {
+	// Command is the command to send to the shell
+	Command string
+
+	// ExpectedCommandOutput is the expected output string to match against
+	ExpectedCommandOutput string
+
+	// FallbackPatterns is a list of regex patterns to match against
+	FallbackPatterns []*regexp.Regexp
+
+	// SuccessMessage is the message to log in case of success
+	SuccessMessage string
+
+	// ExpectedReapedJobEntries is the list of entries expected after the command output appears
+	ExpectedReapedJobEntries []*BackgroundJobStatusEntry
+}
+
+func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	allSingleLinesAssertion := []assertions.SingleLineAssertion{}
+
+	// Add assertion for command's actual output first
+	allSingleLinesAssertion = append(allSingleLinesAssertion, assertions.SingleLineAssertion{
+		ExpectedOutput:   t.ExpectedCommandOutput,
+		FallbackPatterns: t.FallbackPatterns,
+	})
+
+	// Add assertion for reaped job entries now
+	for _, expectedOutputEntry := range t.ExpectedReapedJobEntries {
+		expectedJobMarkerString := convertJobMarkerToString(expectedOutputEntry.Marker)
+
+		expectedOutput := fmt.Sprintf(
+			"[%d]%s  %s                 %s",
+			expectedOutputEntry.JobNumber, expectedJobMarkerString, expectedOutputEntry.Status, expectedOutputEntry.LaunchCommand,
+		)
+
+		// This regex aims to match lines like: [1]+  Done                 sleep 5 &
+		regexString := fmt.Sprintf(
+			`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s$`,
+			expectedOutputEntry.JobNumber,
+			regexp.QuoteMeta(expectedJobMarkerString),
+			regexp.QuoteMeta(expectedOutputEntry.Status),
+			regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
+		)
+
+		allSingleLinesAssertion = append(allSingleLinesAssertion, assertions.SingleLineAssertion{
+			ExpectedOutput:   expectedOutput,
+			FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(regexString)},
+		})
+	}
+
+	// A small delay to ensure that the grep process has exitted
+	time.Sleep(time.Millisecond)
+
+	commandWithMultilineResponseTestCase := CommandWithMultilineResponseTestCase{
+		Command: t.Command,
+		MultiLineAssertion: assertions.MultiLineAssertion{
+			SingleLineAssertions: allSingleLinesAssertion,
+		},
+		SuccessMessage: t.SuccessMessage,
+	}
+
+	if err := commandWithMultilineResponseTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/test_cases/command_response_with_reaped_jobs_test_case.go
+++ b/internal/test_cases/command_response_with_reaped_jobs_test_case.go
@@ -1,7 +1,6 @@
 package test_cases
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 
@@ -39,25 +38,11 @@ func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_assert
 
 	// Add assertion for reaped job entries now
 	for _, expectedOutputEntry := range t.ExpectedReapedJobEntries {
-		expectedJobMarkerString := convertJobMarkerToString(expectedOutputEntry.Marker)
-
-		expectedOutput := fmt.Sprintf(
-			"[%d]%s  %s                 %s",
-			expectedOutputEntry.JobNumber, expectedJobMarkerString, expectedOutputEntry.Status, expectedOutputEntry.LaunchCommand,
-		)
-
-		// This regex aims to match lines like: [1]+  Done                 sleep 5 &
-		regexString := fmt.Sprintf(
-			`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s$`,
-			expectedOutputEntry.JobNumber,
-			regexp.QuoteMeta(expectedJobMarkerString),
-			regexp.QuoteMeta(expectedOutputEntry.Status),
-			regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
-		)
+		expectedOutput, regexPattern := expectedOutputEntry.ExpectedOutputAndRegex()
 
 		allSingleLinesAssertion = append(allSingleLinesAssertion, assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
-			FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(regexString)},
+			FallbackPatterns: []*regexp.Regexp{regexPattern},
 		})
 	}
 

--- a/internal/test_cases/command_response_with_reaped_jobs_test_case.go
+++ b/internal/test_cases/command_response_with_reaped_jobs_test_case.go
@@ -25,6 +25,10 @@ type CommandResponseWithReapedJobsTestCase struct {
 
 	// ExpectedReapedJobEntries is the list of entries expected after the command output appears
 	ExpectedReapedJobEntries []*BackgroundJobStatusEntry
+
+	// ShouldSkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the command reflection
+	// This is usually true when a background command's output has consumed the current prompt line
+	ShouldSkipCurrentPromptAssertion bool
 }
 
 func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
@@ -54,7 +58,8 @@ func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_assert
 		MultiLineAssertion: assertions.MultiLineAssertion{
 			SingleLineAssertions: allSingleLinesAssertion,
 		},
-		SuccessMessage: t.SuccessMessage,
+		ShouldSkipCurrentPromptAssertion: t.ShouldSkipCurrentPromptAssertion,
+		SuccessMessage:                   t.SuccessMessage,
 	}
 
 	if err := commandWithMultilineResponseTestCase.Run(asserter, shell, logger); err != nil {

--- a/internal/test_cases/command_with_multiline_response_test_case.go
+++ b/internal/test_cases/command_with_multiline_response_test_case.go
@@ -19,8 +19,11 @@ type CommandWithMultilineResponseTestCase struct {
 	// SuccessMessage is the message to log in case of success
 	SuccessMessage string
 
-	// SkipAssertPrompt is a flag to indicate that the prompt should not be asserted
-	SkipPromptAssertion bool
+	// ShouldSkipCurrentPromptAssertion should be set if prompt is not expected in the command reflection
+	ShouldSkipCurrentPromptAssertion bool
+
+	// ShouldSkipNextPromptAssertion is a flag to indicate that the prompt should not be asserted
+	ShouldSkipNextPromptAssertion bool
 }
 
 func (t CommandWithMultilineResponseTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
@@ -28,14 +31,21 @@ func (t CommandWithMultilineResponseTestCase) Run(asserter *logged_shell_asserte
 		return fmt.Errorf("Error sending command to shell: %v", err)
 	}
 
-	commandReflection := fmt.Sprintf("$ %s", t.Command)
+	var commandReflection string
+
+	if t.ShouldSkipCurrentPromptAssertion {
+		commandReflection = t.Command
+	} else {
+		commandReflection = fmt.Sprintf("$ %s", t.Command)
+	}
+
 	asserter.AddAssertion(assertions.SingleLineAssertion{
 		ExpectedOutput: commandReflection,
 	})
 
 	asserter.AddAssertion(&t.MultiLineAssertion)
 
-	if !t.SkipPromptAssertion {
+	if !t.ShouldSkipNextPromptAssertion {
 		if err := asserter.AssertWithPrompt(); err != nil {
 			return err
 		}

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -16,7 +16,7 @@ const (
 	PreviousJob
 )
 
-type JobsBuiltinOutputEntry struct {
+type BackgroundJobStatusEntry struct {
 	// The job number value in the square brackets
 	JobNumber int
 	// Status: "Running", "Done", "Terminated", "1 Exit", etc
@@ -28,7 +28,7 @@ type JobsBuiltinOutputEntry struct {
 }
 
 type JobsBuiltinResponseTestCase struct {
-	ExpectedOutputEntries []JobsBuiltinOutputEntry
+	ExpectedOutputEntries []BackgroundJobStatusEntry
 	SuccessMessage        string
 }
 

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -27,6 +27,41 @@ type BackgroundJobStatusEntry struct {
 	Marker int
 }
 
+// ExpectedOutputAndRegex returns the expected output string and regex pattern for this job entry.
+func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Regexp) {
+	expectedJobMarkerString := convertJobMarkerToString(e.Marker)
+
+	// This regex aims to match lines like: [1]+  Running                 sleep 5 &
+	regexString := fmt.Sprintf(
+		`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s`,
+		e.JobNumber,
+		regexp.QuoteMeta(expectedJobMarkerString),
+		regexp.QuoteMeta(e.Status),
+		regexp.QuoteMeta(e.LaunchCommand),
+	)
+
+	// For 'Running' jobs, bash displays the trailing & sign
+	// Users shall comply with bash for consistency (Ensured this by appending this to expected output)
+	// But this should be optional since ZSH doesn't use this
+	if e.Status == "Running" {
+		regexString += "( &)?$"
+	} else {
+		regexString += "$"
+	}
+
+	expectedOutput := fmt.Sprintf(
+		"[%d]%s  %s                 %s",
+		e.JobNumber, expectedJobMarkerString, e.Status, e.LaunchCommand,
+	)
+
+	// For 'Running' jobs, the trailing sign is expected
+	if e.Status == "Running" {
+		expectedOutput += " &"
+	}
+
+	return expectedOutput, regexp.MustCompile(regexString)
+}
+
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []BackgroundJobStatusEntry
 	SuccessMessage        string
@@ -56,39 +91,11 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 	}
 
 	for i, expectedOutputEntry := range t.ExpectedOutputEntries {
-		expectedJobMarkerString := convertJobMarkerToString(expectedOutputEntry.Marker)
-
-		// This regex aims to match lines like: [1]+  Running                 sleep 5 &
-		regexString := fmt.Sprintf(
-			`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s`,
-			expectedOutputEntry.JobNumber,
-			regexp.QuoteMeta(expectedJobMarkerString),
-			regexp.QuoteMeta(expectedOutputEntry.Status),
-			regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
-		)
-
-		// For 'Running' jobs, bash displays the trailing & sign
-		// Users shall comply with bash for consistency (Ensured this by appending this to expected output)
-		// But this should be optional since ZSH doesn't use this
-		if expectedOutputEntry.Status == "Running" {
-			regexString += "( &)?$"
-		} else {
-			regexString += "$"
-		}
-
-		expectedOutput := fmt.Sprintf(
-			"[%d]%s  %s                 %s",
-			expectedOutputEntry.JobNumber, expectedJobMarkerString, expectedOutputEntry.Status, expectedOutputEntry.LaunchCommand,
-		)
-
-		// For 'Running' jobs, the trailing sign is expected
-		if expectedOutputEntry.Status == "Running" {
-			expectedOutput += " &"
-		}
+		expectedOutput, regexPattern := expectedOutputEntry.ExpectedOutputAndRegex()
 
 		asserter.AddAssertion(assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
-			FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(regexString)},
+			FallbackPatterns: []*regexp.Regexp{regexPattern},
 		})
 
 		assertWithPrompt := false

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -1287,6 +1287,20 @@ stages:
     marketing_md: |-
       In this stage, you'll extend the `jobs` builtin to reap multiple jobs and update markers dynamically.
 
+  - slug: "bv8"
+    primary_extension_slug: "background-jobs"
+    name: "Reap before the next prompt"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll add suport for reaping jobs before printing the next prompt.
+
+  - slug: "fy4"
+    primary_extension_slug: "background-jobs"
+    name: "Job number reset"
+    difficulty: easy
+    marketing_md: |-
+      In this stage, you'll implement recycling job number indices.
+
   - slug: "br6"
     primary_extension_slug: "pipelines"
     name: "Dual-command pipeline"

--- a/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
+++ b/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
@@ -4,20 +4,23 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2199[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m[1] 2378[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
+[33m[your-program] [0m[0m$ echo blueberry[0m
+[33m[your-program] [0m[0mblueberry[0m
+[33m[your-program] [0m[0m[1]+ Done                    grep -q raspberry /tmp/pear-70[0m
+[33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ echo mango[0m
 [33m[your-program] [0m[0mmango[0m
-[33m[your-program] [0m[0m[1]+ Done                    grep -q raspberry /tmp/pear-70[0m
-[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[tester::#FY4] [0m[92m✓ Received output for echo[0m
 [33m[your-program] [0m[0m$ jobs[0m
-[33m[tester::#FY4] [0m[92m✓ Received no entries[0m
+[33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[2] 2200[0m
+[33m[your-program] [0m[0m[2] 2382[0m
 [33m[tester::#FY4] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#FY4] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2200"[0m
+[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2382"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#FY4] [0m[91mAssertion failed.[0m
 [33m[tester::#FY4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
+++ b/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
@@ -1,0 +1,23 @@
+Debug = true
+
+[33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/pear-70[0m
+[33m[tester::#FY4] [0m[94mRunning ./your_program.sh[0m
+[33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1] 2199[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
+[33m[your-program] [0m[0m$ echo mango[0m
+[33m[your-program] [0m[0mmango[0m
+[33m[your-program] [0m[0m[1]+ Done                    grep -q raspberry /tmp/pear-70[0m
+[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[tester::#FY4] [0m[92m✓ Received no entries[0m
+[33m[your-program] [0m[0m$ sleep 10 &[0m
+[33m[your-program] [0m[0m[2] 2200[0m
+[33m[tester::#FY4] [0m[91m^ Line does not match expected value.[0m
+[33m[tester::#FY4] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
+[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2200"[0m
+[33m[your-program] [0m[0m$ [0m
+[33m[tester::#FY4] [0m[91mAssertion failed.[0m
+[33m[tester::#FY4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
+++ b/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
@@ -3,13 +3,15 @@ Debug = true
 [33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_program.sh[0m
-[33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2378[0m
+[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1] 2442[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
-[33m[your-program] [0m[0m$ echo blueberry[0m
+[33m[your-program] [0m[0m$ raspberry[0m
+[33m[tester::#FY4] [0m[92m✓ Output of 'grep raspberry /tmp/pear-70' found[0m
+[33m[your-program] [0m[0mecho blueberry[0m
 [33m[your-program] [0m[0mblueberry[0m
-[33m[your-program] [0m[0m[1]+ Done                    grep -q raspberry /tmp/pear-70[0m
+[33m[your-program] [0m[0m[1]+ Done                    grep raspberry /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ echo mango[0m
 [33m[your-program] [0m[0mmango[0m
@@ -17,10 +19,10 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[2] 2382[0m
+[33m[your-program] [0m[0m[2] 2443[0m
 [33m[tester::#FY4] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#FY4] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2382"[0m
+[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2443"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#FY4] [0m[91mAssertion failed.[0m
 [33m[tester::#FY4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,7 +13,7 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2538[0m
+[33m[your-program] [0m[0m[1] 2817[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -21,7 +21,7 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2540[0m
+[33m[your-program] [0m[0m[1] 2819[0m
 [33m[tester::#JD6] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -32,20 +32,20 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2542[0m
+[33m[your-program] [0m[0m[1] 2821[0m
 [33m[tester::#DK5] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ Expected 1 entry for jobs builtin found[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2543[0m
+[33m[your-program] [0m[0m[2] 2822[0m
 [33m[tester::#DK5] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ Expected 2 entries for jobs builtin found[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2544[0m
+[33m[your-program] [0m[0m[3] 2823[0m
 [33m[tester::#DK5] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -59,7 +59,7 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2551[0m
+[33m[your-program] [0m[0m[1] 2825[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    grep -q raspberry /tmp/pear-70 &[0m
 [33m[tester::#MA9] [0m[92mExpected 1 entry found in the output[0m
@@ -75,11 +75,11 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/banana-67[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2553[0m
+[33m[your-program] [0m[0m[1] 2827[0m
 [33m[your-program] [0m[0m$ grep -q banana /tmp/mango-20 &[0m
-[33m[your-program] [0m[0m[2] 2554[0m
+[33m[your-program] [0m[0m[2] 2828[0m
 [33m[your-program] [0m[0m$ grep -q pear /tmp/banana-67 &[0m
-[33m[your-program] [0m[0m[3] 2555[0m
+[33m[your-program] [0m[0m[3] 2829[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "banana" > "/tmp/mango-20"[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 500 &[0m
@@ -96,3 +96,69 @@ Debug = true
 [33m[tester::#RQ2] [0m[92mExpected 1 entries found in the output[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#RQ2] [0m[92mTest passed.[0m
+
+[33m[tester::#BV8] [0m[94mRunning tests for Stage #BV8 (bv8)[0m
+[33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/orange-80[0m
+[33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
+[33m[your-program] [0m[0m[1] 2831[0m
+[33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m$ grep -q grape /tmp/orange-80 &[0m
+[33m[your-program] [0m[0m[2] 2832[0m
+[33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
+[33m[your-program] [0m[0m[2]+  Running                    grep -q grape /tmp/orange-80 &[0m
+[33m[tester::#BV8] [0m[92m✓ Received 2 entries for the running jobs[0m
+[33m[tester::#BV8] [setup] [0m[94mecho "grape" > "/tmp/orange-80"[0m
+[33m[your-program] [0m[0m$ echo apple[0m
+[33m[your-program] [0m[0mapple[0m
+[33m[your-program] [0m[0m[2]+  Done                       grep -q grape /tmp/orange-80[0m
+[33m[tester::#BV8] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m
+[33m[tester::#BV8] [0m[92m✓ Received 1 entry for the remaining running job[0m
+[33m[your-program] [0m[0m$ [0m
+[33m[tester::#BV8] [0m[92mTest passed.[0m
+
+[33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-16[0m
+[33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ grep -q mango /tmp/apple-16 &[0m
+[33m[your-program] [0m[0m[1] 2834[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[tester::#FY4] [setup] [0m[94mecho "mango" > "/tmp/apple-16"[0m
+[33m[your-program] [0m[0m$ echo grape[0m
+[33m[your-program] [0m[0mgrape[0m
+[33m[your-program] [0m[0m[1]+  Done                       grep -q mango /tmp/apple-16[0m
+[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[tester::#FY4] [0m[92m✓ Received no entries[0m
+[33m[your-program] [0m[0m$ sleep 10 &[0m
+[33m[your-program] [0m[0m[1] 2835[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
+[33m[tester::#FY4] [0m[92m✓ Received 1 entry for the running job[0m
+[33m[tester::#FY4] [0m[94mTearing down shell[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/banana-47[0m
+[33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ sleep 100 &[0m
+[33m[your-program] [0m[0m[1] 2837[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m$ grep -q apple /tmp/banana-47 &[0m
+[33m[your-program] [0m[0m[2] 2838[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[tester::#FY4] [setup] [0m[94mecho "apple" > "/tmp/banana-47"[0m
+[33m[your-program] [0m[0m$ echo pear[0m
+[33m[your-program] [0m[0mpear[0m
+[33m[your-program] [0m[0m[2]+  Done                       grep -q apple /tmp/banana-47[0m
+[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[your-program] [0m[0m$ sleep 50 &[0m
+[33m[your-program] [0m[0m[2] 2839[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
+[33m[your-program] [0m[0m[2]+  Running                    sleep 50 &[0m
+[33m[tester::#FY4] [0m[92m✓ Received 2 entries for the running jobs[0m
+[33m[your-program] [0m[0m$ [0m
+[33m[tester::#FY4] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,7 +13,7 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2011[0m
+[33m[your-program] [0m[0m[1] 2385[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -21,7 +21,7 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2014[0m
+[33m[your-program] [0m[0m[1] 2387[0m
 [33m[tester::#JD6] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -32,20 +32,20 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2017[0m
+[33m[your-program] [0m[0m[1] 2392[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ Received 1 entry for the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2019[0m
+[33m[your-program] [0m[0m[2] 2393[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ Received 2 entries for the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2021[0m
+[33m[your-program] [0m[0m[3] 2394[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -59,7 +59,7 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2023[0m
+[33m[your-program] [0m[0m[1] 2397[0m
 [33m[tester::#MA9] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    grep -q raspberry /tmp/pear-70 &[0m
@@ -76,13 +76,13 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/mango-16[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2025[0m
+[33m[your-program] [0m[0m[1] 2399[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ grep -q mango /tmp/blueberry-26 &[0m
-[33m[your-program] [0m[0m[2] 2026[0m
+[33m[your-program] [0m[0m[2] 2400[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ grep -q grape /tmp/mango-16 &[0m
-[33m[your-program] [0m[0m[3] 2027[0m
+[33m[your-program] [0m[0m[3] 2401[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "mango" > "/tmp/blueberry-26"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -105,23 +105,23 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/banana-47[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2030[0m
-[33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m[1] 2405[0m
+[33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ grep -q apple /tmp/banana-47 &[0m
-[33m[your-program] [0m[0m[2] 2031[0m
-[33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m[2] 2406[0m
+[33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    grep -q apple /tmp/banana-47 &[0m
-[33m[tester::#BV8] [0m[92m✓ Received 2 entries for the running jobs[0m
+[33m[tester::#BV8] [0m[92m✓ Found 2 entries for the running jobs[0m
 [33m[tester::#BV8] [setup] [0m[94mecho "apple" > "/tmp/banana-47"[0m
 [33m[your-program] [0m[0m$ echo pear[0m
 [33m[your-program] [0m[0mpear[0m
 [33m[your-program] [0m[0m[2]+  Done                       grep -q apple /tmp/banana-47[0m
-[33m[tester::#BV8] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[tester::#BV8] [0m[92m✓ Found command output followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m
-[33m[tester::#BV8] [0m[92m✓ Received 1 entry for the remaining running job[0m
+[33m[tester::#BV8] [0m[92m✓ 1 entry matches the running job[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#BV8] [0m[92mTest passed.[0m
 
@@ -129,41 +129,44 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/banana-39[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/banana-39 &[0m
-[33m[your-program] [0m[0m[1] 2033[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m[1] 2410[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/banana-39"[0m
+[33m[your-program] [0m[0m$ echo banana[0m
+[33m[your-program] [0m[0mbanana[0m
+[33m[your-program] [0m[0m[1]+  Done                       grep -q raspberry /tmp/banana-39[0m
+[33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ echo apple[0m
 [33m[your-program] [0m[0mapple[0m
-[33m[your-program] [0m[0m[1]+  Done                       grep -q raspberry /tmp/banana-39[0m
-[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[tester::#FY4] [0m[92m✓ Received output for echo[0m
 [33m[your-program] [0m[0m$ jobs[0m
-[33m[tester::#FY4] [0m[92m✓ Received no entries[0m
+[33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2035[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for started job[0m
+[33m[your-program] [0m[0m[1] 2411[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
-[33m[tester::#FY4] [0m[92m✓ Received 1 entry for the running job[0m
+[33m[tester::#FY4] [0m[92m✓ 1 entry matches the running job[0m
 [33m[tester::#FY4] [0m[94mTearing down shell[0m
-[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-52[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/strawberry-88[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2037[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
-[33m[your-program] [0m[0m$ grep -q banana /tmp/apple-52 &[0m
-[33m[your-program] [0m[0m[2] 2039[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
-[33m[tester::#FY4] [setup] [0m[94mecho "banana" > "/tmp/apple-52"[0m
-[33m[your-program] [0m[0m$ echo pear[0m
-[33m[your-program] [0m[0mpear[0m
-[33m[your-program] [0m[0m[2]+  Done                       grep -q banana /tmp/apple-52[0m
-[33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
+[33m[your-program] [0m[0m[1] 2414[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
+[33m[your-program] [0m[0m$ grep -q pineapple /tmp/strawberry-88 &[0m
+[33m[your-program] [0m[0m[2] 2415[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
+[33m[tester::#FY4] [setup] [0m[94mecho "pineapple" > "/tmp/strawberry-88"[0m
+[33m[your-program] [0m[0m$ echo apple[0m
+[33m[your-program] [0m[0mapple[0m
+[33m[your-program] [0m[0m[2]+  Done                       grep -q pineapple /tmp/strawberry-88[0m
+[33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2040[0m
-[33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
+[33m[your-program] [0m[0m[2] 2416[0m
+[33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 50 &[0m
-[33m[tester::#FY4] [0m[92m✓ Received 2 entries for the running jobs[0m
+[33m[tester::#FY4] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#FY4] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,7 +13,7 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2222[0m
+[33m[your-program] [0m[0m[1] 2011[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -21,7 +21,7 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2225[0m
+[33m[your-program] [0m[0m[1] 2014[0m
 [33m[tester::#JD6] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -32,20 +32,20 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2228[0m
+[33m[your-program] [0m[0m[1] 2017[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ Received 1 entry for the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2229[0m
+[33m[your-program] [0m[0m[2] 2019[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ Received 2 entries for the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2233[0m
+[33m[your-program] [0m[0m[3] 2021[0m
 [33m[tester::#DK5] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -59,7 +59,7 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2239[0m
+[33m[your-program] [0m[0m[1] 2023[0m
 [33m[tester::#MA9] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    grep -q raspberry /tmp/pear-70 &[0m
@@ -76,13 +76,13 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/mango-16[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2241[0m
+[33m[your-program] [0m[0m[1] 2025[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ grep -q mango /tmp/blueberry-26 &[0m
-[33m[your-program] [0m[0m[2] 2242[0m
+[33m[your-program] [0m[0m[2] 2026[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[your-program] [0m[0m$ grep -q grape /tmp/mango-16 &[0m
-[33m[your-program] [0m[0m[3] 2243[0m
+[33m[your-program] [0m[0m[3] 2027[0m
 [33m[tester::#RQ2] [0m[92m✓ Received entry for the started job[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "mango" > "/tmp/blueberry-26"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -105,10 +105,10 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/banana-47[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2245[0m
+[33m[your-program] [0m[0m[1] 2030[0m
 [33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
 [33m[your-program] [0m[0m$ grep -q apple /tmp/banana-47 &[0m
-[33m[your-program] [0m[0m[2] 2246[0m
+[33m[your-program] [0m[0m[2] 2031[0m
 [33m[tester::#BV8] [0m[92m✓ Received entry for the launched job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -129,7 +129,7 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/banana-39[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ grep -q raspberry /tmp/banana-39 &[0m
-[33m[your-program] [0m[0m[1] 2248[0m
+[33m[your-program] [0m[0m[1] 2033[0m
 [33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/banana-39"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -139,7 +139,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ Received no entries[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2249[0m
+[33m[your-program] [0m[0m[1] 2035[0m
+[33m[tester::#FY4] [0m[92m✓ Received entry for started job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
 [33m[tester::#FY4] [0m[92m✓ Received 1 entry for the running job[0m
@@ -147,10 +148,10 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-52[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2253[0m
+[33m[your-program] [0m[0m[1] 2037[0m
 [33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
 [33m[your-program] [0m[0m$ grep -q banana /tmp/apple-52 &[0m
-[33m[your-program] [0m[0m[2] 2254[0m
+[33m[your-program] [0m[0m[2] 2039[0m
 [33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "banana" > "/tmp/apple-52"[0m
 [33m[your-program] [0m[0m$ echo pear[0m
@@ -158,7 +159,7 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       grep -q banana /tmp/apple-52[0m
 [33m[tester::#FY4] [0m[92m✓ Received command output followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2255[0m
+[33m[your-program] [0m[0m[2] 2040[0m
 [33m[tester::#FY4] [0m[92m✓ Received entry for the launched job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,7 +13,7 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2041[0m
+[33m[your-program] [0m[0m[1] 2832[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -21,7 +21,7 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2044[0m
+[33m[your-program] [0m[0m[1] 2834[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -32,20 +32,20 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2047[0m
+[33m[your-program] [0m[0m[1] 2836[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2049[0m
+[33m[your-program] [0m[0m[2] 2837[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2050[0m
+[33m[your-program] [0m[0m[3] 2838[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -59,7 +59,7 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2052[0m
+[33m[your-program] [0m[0m[1] 2840[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    grep raspberry /tmp/pear-70 &[0m
@@ -78,13 +78,13 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/mango-16[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2055[0m
+[33m[your-program] [0m[0m[1] 2842[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ grep mango /tmp/blueberry-26 &[0m
-[33m[your-program] [0m[0m[2] 2056[0m
+[33m[your-program] [0m[0m[2] 2843[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ grep grape /tmp/mango-16 &[0m
-[33m[your-program] [0m[0m[3] 2057[0m
+[33m[your-program] [0m[0m[3] 2844[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "mango" > "/tmp/blueberry-26"[0m
 [33m[your-program] [0m[0m$ mango[0m
@@ -111,19 +111,21 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/banana-47[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2060[0m
+[33m[your-program] [0m[0m[1] 2846[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q apple /tmp/banana-47 &[0m
-[33m[your-program] [0m[0m[2] 2061[0m
+[33m[your-program] [0m[0m$ grep apple /tmp/banana-47 &[0m
+[33m[your-program] [0m[0m[2] 2847[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[2]+  Running                    grep -q apple /tmp/banana-47 &[0m
+[33m[your-program] [0m[0m[2]+  Running                    grep apple /tmp/banana-47 &[0m
 [33m[tester::#BV8] [0m[92m✓ Found 2 entries for the running jobs[0m
 [33m[tester::#BV8] [setup] [0m[94mecho "apple" > "/tmp/banana-47"[0m
-[33m[your-program] [0m[0m$ echo pear[0m
+[33m[your-program] [0m[0m$ apple[0m
+[33m[tester::#BV8] [0m[92m✓ Output of 'grep apple /tmp/banana-47' found[0m
+[33m[your-program] [0m[0mecho pear[0m
 [33m[your-program] [0m[0mpear[0m
-[33m[your-program] [0m[0m[2]+  Done                       grep -q apple /tmp/banana-47[0m
+[33m[your-program] [0m[0m[2]+  Done                       grep apple /tmp/banana-47[0m
 [33m[tester::#BV8] [0m[92m✓ Found command output followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m
@@ -134,13 +136,15 @@ Debug = true
 [33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/banana-39[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ grep -q raspberry /tmp/banana-39 &[0m
-[33m[your-program] [0m[0m[1] 2064[0m
+[33m[your-program] [0m[0m$ grep raspberry /tmp/banana-39 &[0m
+[33m[your-program] [0m[0m[1] 2849[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/banana-39"[0m
-[33m[your-program] [0m[0m$ echo banana[0m
+[33m[your-program] [0m[0m$ raspberry[0m
+[33m[tester::#FY4] [0m[92m✓ Output of 'grep raspberry /tmp/banana-39' found[0m
+[33m[your-program] [0m[0mecho banana[0m
 [33m[your-program] [0m[0mbanana[0m
-[33m[your-program] [0m[0m[1]+  Done                       grep -q raspberry /tmp/banana-39[0m
+[33m[your-program] [0m[0m[1]+  Done                       grep raspberry /tmp/banana-39[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ echo apple[0m
 [33m[your-program] [0m[0mapple[0m
@@ -148,7 +152,7 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2066[0m
+[33m[your-program] [0m[0m[1] 2850[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -157,18 +161,20 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/strawberry-88[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2068[0m
+[33m[your-program] [0m[0m[1] 2852[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q pineapple /tmp/strawberry-88 &[0m
-[33m[your-program] [0m[0m[2] 2069[0m
+[33m[your-program] [0m[0m$ grep pineapple /tmp/strawberry-88 &[0m
+[33m[your-program] [0m[0m[2] 2853[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho "pineapple" > "/tmp/strawberry-88"[0m
-[33m[your-program] [0m[0m$ echo apple[0m
+[33m[your-program] [0m[0m$ pineapple[0m
+[33m[tester::#FY4] [0m[92m✓ Output of 'grep pineapple /tmp/strawberry-88' found[0m
+[33m[your-program] [0m[0mecho apple[0m
 [33m[your-program] [0m[0mapple[0m
-[33m[your-program] [0m[0m[2]+  Done                       grep -q pineapple /tmp/strawberry-88[0m
+[33m[your-program] [0m[0m[2]+  Done                       grep pineapple /tmp/strawberry-88[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2071[0m
+[33m[your-program] [0m[0m[2] 2854[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/codecrafters.yml
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
@@ -89,7 +89,7 @@ def run_builtin(args: list[str], last_exit_code: int) -> tuple[str | None, int |
                 marker = " "
             line = f"[{jid}]{marker}  Running                 {cmd_line}"
             lines.append(line)
-            return "\n".join(lines) if lines else None, None
+        return "\n".join(lines) if lines else None, None
     return None, None
 
 

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Minimal shell that passes base stages oo8--ip1: prompt, invalid command, REPL, exit, echo, type, run."""
+
+import cmd
+import os
+import sys
+import subprocess
+import shlex
+
+PROMPT = "$ "
+BUILTINS = {"echo", "exit", "type", "jobs"}
+
+# List of background jobs: {"job_id": int, "cmd_line": str, "process": Popen}
+BACKGROUND_JOBS: list[dict] = []
+# Next job number to assign; never recycled after reaping (intentional error scenario).
+NEXT_JOB_ID: int = 1
+
+
+def reap_finished_jobs() -> None:
+    """Remove any background job whose process has exited."""
+    global BACKGROUND_JOBS
+    BACKGROUND_JOBS = [j for j in BACKGROUND_JOBS if j["process"].poll() is None]
+
+def notify_and_reap_jobs() -> None:
+    """Print finished jobs, then remove them."""
+    global BACKGROUND_JOBS
+    alive = []
+    for job in BACKGROUND_JOBS:
+        proc = job["process"]
+        if proc.poll() is not None:
+            jid = job["job_id"]
+            cmd_line = job["cmd_line"]
+            # For Done, don't print trailing &
+            cmd_line = cmd_line.removesuffix(" &")
+            # Since this is only used for fy4; hardcoding this for now
+            print(f"[{jid}]+ Done                    {cmd_line}")
+        else:
+            alive.append(job)
+    BACKGROUND_JOBS = alive
+
+def find_in_path(name: str) -> str | None:
+    """First executable in PATH with this name (skip non-executable)."""
+    path = os.environ.get("PATH", "")
+    for part in path.split(os.pathsep):
+        if not part:
+            continue
+        full = os.path.join(part, name)
+        if os.path.isfile(full) and os.access(full, os.X_OK):
+            return full
+    return None
+
+
+def run_builtin(args: list[str], last_exit_code: int) -> tuple[str | None, int | None]:
+    """Run builtin. Returns (output_line_or_None, exit_code_or_None). None means continue (no exit)."""
+    if not args:
+        return None, None
+    cmd = args[0].lower()
+    if cmd == "exit":
+        code = int(args[1]) if len(args) > 1 else last_exit_code
+        if code < 0:
+            code = 0
+        return None, code
+    if cmd == "echo":
+        out = " ".join(args[1:]) if len(args) > 1 else ""
+        return out, None
+    if cmd == "type":
+        if len(args) < 2:
+            return None, None
+        name = args[1]
+        if name in BUILTINS:
+            return f"{name} is a shell builtin", None
+        path = find_in_path(name)
+        if path:
+            return f"{name} is {path}", None
+        return f"{name}: not found", None
+    if cmd == "jobs":
+        reap_finished_jobs()
+        lines = []
+        for i, job in enumerate(BACKGROUND_JOBS):
+            jid = job["job_id"]
+            cmd_line = job["cmd_line"]
+            # + for current (last), - for previous (second-last), space otherwise
+            n = len(BACKGROUND_JOBS)
+            if i == n - 1:
+                marker = "+"
+            elif n >= 2 and i == n - 2:
+                marker = "-"
+            else:
+                marker = " "
+            line = f"[{jid}]{marker}  Running                 {cmd_line}"
+            lines.append(line)
+            return "\n".join(lines) if lines else None, None
+    return None, None
+
+
+def run_external(args: list[str], background: bool = False) -> tuple[int | None, subprocess.Popen | None]:
+    """Run external command. Returns (exit_code, None) or (None, proc) if background."""
+    name = args[0]
+    path = find_in_path(name)
+    if path is None:
+        print(f"{name}: command not found", file=sys.stderr)
+        return (127, None)
+    try:
+        if background:
+            proc = subprocess.Popen(
+                [path] + args[1:],
+                env=os.environ,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return (None, proc)
+        proc = subprocess.run(
+            [path] + args[1:],
+            env=os.environ,
+            capture_output=False,
+            timeout=30,
+        )
+        return (proc.returncode, None)
+    except (OSError, subprocess.TimeoutExpired):
+        return (127, None)
+
+
+def main() -> None:
+    global NEXT_JOB_ID
+    last_exit_code = 0
+    while True:
+        sys.stdout.write(PROMPT)
+        sys.stdout.flush()
+        try:
+            line = sys.stdin.readline()
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not line:
+            break
+        line = line.rstrip("\n\r")
+        background = line.rstrip().endswith("&")
+        if background:
+            line = line.rstrip()[:-1].rstrip()
+        parts = shlex.split(line)
+        if not parts:
+            continue
+        cmd = parts[0]
+        args = parts[1:]
+
+        if cmd in BUILTINS:
+            out, exit_code = run_builtin([cmd] + args, last_exit_code)
+            if exit_code is not None:
+                sys.exit(exit_code)
+            if out is not None:
+                print(out)
+                sys.stdout.flush()
+        else:
+            exit_code, bg_proc = run_external([cmd] + args, background=background)
+            if exit_code is not None:
+                last_exit_code = exit_code
+            else:
+                job_id = NEXT_JOB_ID
+                NEXT_JOB_ID += 1
+                cmd_line = " ".join([cmd] + args) + " &"
+                BACKGROUND_JOBS.append({"job_id": job_id, "cmd_line": cmd_line, "process": bg_proc})
+                print(f"[{job_id}] {bg_proc.pid}")
+                sys.stdout.flush()
+        notify_and_reap_jobs()
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
@@ -105,8 +105,6 @@ def run_external(args: list[str], background: bool = False) -> tuple[int | None,
             proc = subprocess.Popen(
                 [path] + args[1:],
                 env=os.environ,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
             return (None, proc)
         proc = subprocess.run(

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/your_program.sh
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/your_program.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# This buggy implementation of shell will never recycle job numbers and keep on increasing
+exec python3 $(dirname "$0")/main.py "$@"

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -222,6 +222,16 @@ var testerDefinition = tester_definition.TesterDefinition{
 			TestFunc: testBG6,
 			Timeout:  15 * time.Second,
 		},
+		{
+			Slug:     "bv8",
+			TestFunc: testBG7,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "fy4",
+			TestFunc: testBG8,
+			Timeout:  15 * time.Second,
+		},
 		// Pipelines
 		{
 			Slug:     "br6",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates core background-jobs test harness and prompt-assertion behavior, which could change pass/fail outcomes across multiple stages if the new expectations are off. Scope is mostly confined to tester logic/fixtures, not runtime code, but impacts grading reliability.
> 
> **Overview**
> **Adds new Background Jobs coverage (Stages `bv8` + `fy4`).** The tester now verifies that finished background jobs can be *reaped/printed before the next prompt* (by asserting a `Done` job line appears immediately after a subsequent command’s output) and that *job numbers are recycled/reset* after all jobs are reaped (including across a shell restart).
> 
> **Refactors tester assertions for jobs + prompts.** `JobsBuiltinOutputEntry` is replaced with `BackgroundJobStatusEntry` (centralized expected output + regex generation), introduces `CommandResponseWithReapedJobsTestCase` for command output followed by reaped-job lines, and splits multiline command prompt handling into `ShouldSkipCurrentPromptAssertion` vs `ShouldSkipNextPromptAssertion` (updating pipeline stage `testP1`). Test definitions/fixtures and course metadata are updated accordingly, including a new failing scenario `background_jobs_job_number_not_recycled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02bd1bad74302bf1c02356c04af9fb796ee2825d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->