### PR TITLE
Jobs command issues

### DIFF
--- a/internal/test_cases/command_response_with_reaped_jobs_test_case.go
+++ b/internal/test_cases/command_response_with_reaped_jobs_test_case.go
@@ -1,7 +1,6 @@
 package test_cases
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 
@@ -39,25 +38,11 @@ func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_assert
 
 	// Add assertion for reaped job entries now
 	for _, expectedOutputEntry := range t.ExpectedReapedJobEntries {
-		expectedJobMarkerString := convertJobMarkerToString(expectedOutputEntry.Marker)
-
-		expectedOutput := fmt.Sprintf(
-			"[%d]%s  %s                 %s",
-			expectedOutputEntry.JobNumber, expectedJobMarkerString, expectedOutputEntry.Status, expectedOutputEntry.LaunchCommand,
-		)
-
-		// This regex aims to match lines like: [1]+  Done                 sleep 5 &
-		regexString := fmt.Sprintf(
-			`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s$`,
-			expectedOutputEntry.JobNumber,
-			regexp.QuoteMeta(expectedJobMarkerString),
-			regexp.QuoteMeta(expectedOutputEntry.Status),
-			regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
-		)
+		expectedOutput, regexPattern := expectedOutputEntry.ExpectedOutputAndRegex()
 
 		allSingleLinesAssertion = append(allSingleLinesAssertion, assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
-			FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(regexString)},
+			FallbackPatterns: []*regexp.Regexp{regexPattern},
 		})
 	}
 

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -27,6 +27,41 @@ type BackgroundJobStatusEntry struct {
 	Marker int
 }
 
+// ExpectedOutputAndRegex returns the expected output string and regex pattern for this job entry.
+func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Regexp) {
+	expectedJobMarkerString := convertJobMarkerToString(e.Marker)
+
+	// This regex aims to match lines like: [1]+  Running                 sleep 5 &
+	regexString := fmt.Sprintf(
+		`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s`,
+		e.JobNumber,
+		regexp.QuoteMeta(expectedJobMarkerString),
+		regexp.QuoteMeta(e.Status),
+		regexp.QuoteMeta(e.LaunchCommand),
+	)
+
+	// For 'Running' jobs, bash displays the trailing & sign
+	// Users shall comply with bash for consistency (Ensured this by appending this to expected output)
+	// But this should be optional since ZSH doesn't use this
+	if e.Status == "Running" {
+		regexString += "( &)?$"
+	} else {
+		regexString += "$"
+	}
+
+	expectedOutput := fmt.Sprintf(
+		"[%d]%s  %s                 %s",
+		e.JobNumber, expectedJobMarkerString, e.Status, e.LaunchCommand,
+	)
+
+	// For 'Running' jobs, the trailing sign is expected
+	if e.Status == "Running" {
+		expectedOutput += " &"
+	}
+
+	return expectedOutput, regexp.MustCompile(regexString)
+}
+
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []BackgroundJobStatusEntry
 	SuccessMessage        string
@@ -56,39 +91,11 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 	}
 
 	for i, expectedOutputEntry := range t.ExpectedOutputEntries {
-		expectedJobMarkerString := convertJobMarkerToString(expectedOutputEntry.Marker)
-
-		// This regex aims to match lines like: [1]+  Running                 sleep 5 &
-		regexString := fmt.Sprintf(
-			`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s`,
-			expectedOutputEntry.JobNumber,
-			regexp.QuoteMeta(expectedJobMarkerString),
-			regexp.QuoteMeta(expectedOutputEntry.Status),
-			regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
-		)
-
-		// For 'Running' jobs, bash displays the trailing & sign
-		// Users shall comply with bash for consistency (Ensured this by appending this to expected output)
-		// But this should be optional since ZSH doesn't use this
-		if expectedOutputEntry.Status == "Running" {
-			regexString += "( &)?$"
-		} else {
-			regexString += "$"
-		}
-
-		expectedOutput := fmt.Sprintf(
-			"[%d]%s  %s                 %s",
-			expectedOutputEntry.JobNumber, expectedJobMarkerString, expectedOutputEntry.Status, expectedOutputEntry.LaunchCommand,
-		)
-
-		// For 'Running' jobs, the trailing sign is expected
-		if expectedOutputEntry.Status == "Running" {
-			expectedOutput += " &"
-		}
+		expectedOutput, regexPattern := expectedOutputEntry.ExpectedOutputAndRegex()
 
 		asserter.AddAssertion(assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
-			FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(regexString)},
+			FallbackPatterns: []*regexp.Regexp{regexPattern},
 		})
 
 		assertWithPrompt := false

--- a/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_job_number_not_recycled/main.py
@@ -89,7 +89,7 @@ def run_builtin(args: list[str], last_exit_code: int) -> tuple[str | None, int |
                 marker = " "
             line = f"[{jid}]{marker}  Running                 {cmd_line}"
             lines.append(line)
-            return "\n".join(lines) if lines else None, None
+        return "\n".join(lines) if lines else None, None
     return None, None
 
 


### PR DESCRIPTION
Fix a Python logic bug in job output generation and refactor Go test cases to centralize job entry formatting.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and a Python scenario shell; main risk is altering regex expectations for `jobs`/reaped-job output formatting, which could change test outcomes.
> 
> **Overview**
> **Centralizes `jobs`/reaped-job output expectations in Go tests.** Adds `BackgroundJobStatusEntry.ExpectedOutputAndRegex()` and updates both `JobsBuiltinResponseTestCase` and `CommandResponseWithReapedJobsTestCase` to use it instead of duplicating `fmt`/regex construction (including the special-case optional trailing `&` for `Running`).
> 
> **Fixes a logic bug in the Python scenario `jobs` output.** Corrects indentation so the `jobs` builtin returns the full multi-line listing after iterating all background jobs, rather than returning early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df903152396ad0904755b8ea9a8c1e4ddcdfa157. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->