### PR TITLE
Add background cmd output check in stages 5 and 6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 // replace github.com/codecrafters-io/tester-utils v0.2.22 => /Users/rohitpaulk/experiments/codecrafters/tester-utils
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	github.com/charmbracelet/x/ansi v0.7.0 // indirect
 	github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/charmbracelet/x/ansi v0.7.0 h1:/QfFmiXOGGwN6fRbzvQaYp7fu1pkxpZ3qFBZWBsP404=
 github.com/charmbracelet/x/ansi v0.7.0/go.mod h1:KBUFw1la39nl0dLl10l5ORDAqGXaeurTQmwyyVKse/Q=
 github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d h1:cIxw4y+aEGuxgofJdiZnD+wyNvD03k0ViFsSOBiyGiU=

--- a/internal/stage_bg5.go
+++ b/internal/stage_bg5.go
@@ -79,8 +79,8 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 			LaunchCommand: bgGrepCommand,
 			Marker:        test_cases.CurrentJob,
 		}},
-		SkipCurrentPromptAssertion: true,
-		SuccessMessage:             "✓ 1 entry matches the finished job",
+		ShouldSkipCurrentPromptAssertion: true,
+		SuccessMessage:                   "✓ 1 entry matches the finished job",
 	}
 
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {

--- a/internal/stage_bg5.go
+++ b/internal/stage_bg5.go
@@ -27,7 +27,7 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep -q %s %s", grepPattern, fifoPath)
+	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
 
 	bgJobTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand,
@@ -62,6 +62,15 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 	// A small delay since grep takes some time to process and exit
 	time.Sleep(time.Millisecond)
 
+	err := test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern},
+		SuccessMessage:      "✓ Output of background command 'grep' found",
+	}.Run(asserter, shell, logger)
+
+	if err != nil {
+		return err
+	}
+
 	// Call jobs again
 	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
 		ExpectedOutputEntries: []test_cases.JobsBuiltinOutputEntry{{
@@ -70,7 +79,8 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 			LaunchCommand: bgGrepCommand,
 			Marker:        test_cases.CurrentJob,
 		}},
-		SuccessMessage: "✓ 1 entry matches the finished job",
+		SkipCurrentPromptAssertion: true,
+		SuccessMessage:             "✓ 1 entry matches the finished job",
 	}
 
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -94,8 +94,8 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 3, Status: "Running", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
 		},
 		// Because background command will have consumed the prompt line
-		SkipCurrentPromptAssertion: true,
-		SuccessMessage:             "✓ Received 3 entries in the output",
+		ShouldSkipCurrentPromptAssertion: true,
+		SuccessMessage:                   "✓ Received 3 entries in the output",
 	}
 
 	if err := jobsBuiltinTestCase1.Run(asserter, shell, logger); err != nil {
@@ -126,8 +126,8 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 3, Status: "Done", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
 		},
 		// Prompt will have been consumed by the background command output
-		SkipCurrentPromptAssertion: true,
-		SuccessMessage:             "✓ Received 2 entries in the output",
+		ShouldSkipCurrentPromptAssertion: true,
+		SuccessMessage:                   "✓ Received 2 entries in the output",
 	}
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -74,6 +74,8 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	time.Sleep(time.Millisecond)
+
 	// Assert the background command's output
 	err := test_cases.BackgroundCommandOutputOnlyTestCase{
 		ExpectedOutputLines: []string{grepPattern1},
@@ -83,8 +85,6 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-
-	time.Sleep(time.Millisecond)
 
 	// Call jobs for the first time
 	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -45,7 +46,7 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 	// Launch 'grep read pattern' to hang the process indefinitely
 
 	grepPattern1 := random.RandomWord()
-	bgGrepCommand1 := fmt.Sprintf("grep -q %s %s", grepPattern1, fifoPath1)
+	bgGrepCommand1 := fmt.Sprintf("grep %s %s", grepPattern1, fifoPath1)
 	bgGrepTestCase1 := test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand1,
 		ExpectedJobNumber: 2,
@@ -57,7 +58,7 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Launch grep read pattern again
 	grepPattern2 := random.RandomWord()
-	bgGrepCommand2 := fmt.Sprintf("grep -q %s %s", grepPattern2, fifoPath2)
+	bgGrepCommand2 := fmt.Sprintf("grep %s %s", grepPattern2, fifoPath2)
 	bgGrepTestCase2 := test_cases.BackgroundCommandResponseTestCase{
 		Command:           bgGrepCommand2,
 		ExpectedJobNumber: 3,
@@ -73,6 +74,16 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	// Assert the background command's output
+	err := test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern1},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand1)),
+	}.Run(asserter, shell, logger)
+
+	if err != nil {
+		return err
+	}
+
 	time.Sleep(time.Millisecond)
 
 	// Call jobs for the first time
@@ -82,8 +93,11 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.PreviousJob},
 			{JobNumber: 3, Status: "Running", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received 3 entries in the output",
+		// Because background command will have consumed the prompt line
+		SkipCurrentPromptAssertion: true,
+		SuccessMessage:             "✓ Received 3 entries in the output",
 	}
+
 	if err := jobsBuiltinTestCase1.Run(asserter, shell, logger); err != nil {
 		return err
 	}
@@ -92,7 +106,18 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := WriteToFile(stageHarness, fifoPath2, grepPattern2); err != nil {
 		return err
 	}
+
 	time.Sleep(time.Millisecond)
+
+	// Assert the background command's output
+	err = test_cases.BackgroundCommandOutputOnlyTestCase{
+		ExpectedOutputLines: []string{grepPattern2},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand2)),
+	}.Run(asserter, shell, logger)
+
+	if err != nil {
+		return err
+	}
 
 	// Call jobs for the second time
 	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
@@ -100,7 +125,9 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
 			{JobNumber: 3, Status: "Done", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Received 2 entries in the output",
+		// Prompt will have been consumed by the background command output
+		SkipCurrentPromptAssertion: true,
+		SuccessMessage:             "✓ Received 2 entries in the output",
 	}
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
 		return err

--- a/internal/test_cases/background_command_output_only_test_case.go
+++ b/internal/test_cases/background_command_output_only_test_case.go
@@ -1,0 +1,41 @@
+package test_cases
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type BackgroundCommandOutputOnlyTestCase struct {
+	ExpectedOutputLines []string
+	SuccessMessage      string
+}
+
+func (t BackgroundCommandOutputOnlyTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	if len(t.ExpectedOutputLines) == 0 {
+		panic("Codecrafters Internal Error - ExpectedOutputLines is empty in BackgroundCommandOutputOnlyTestCase")
+	}
+
+	outputInPromptLine := t.ExpectedOutputLines[0]
+
+	promptLineReflection := fmt.Sprintf("$ %s", outputInPromptLine)
+	asserter.AddAssertion(assertions.SingleLineAssertion{
+		ExpectedOutput: promptLineReflection,
+	})
+
+	remainingOutputLinesAssertion := assertions.NewMultiLineAssertion(t.ExpectedOutputLines[1:])
+	asserter.AddAssertion(&remainingOutputLinesAssertion)
+
+	if err := asserter.AssertWithoutPrompt(); err != nil {
+		return err
+	}
+
+	if t.SuccessMessage != "" {
+		logger.Successf("%s", t.SuccessMessage)
+	}
+
+	return nil
+}

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -29,7 +29,9 @@ type JobsBuiltinOutputEntry struct {
 
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []JobsBuiltinOutputEntry
-	SuccessMessage        string
+	// SkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the 'jobs' command reflection
+	SkipCurrentPromptAssertion bool
+	SuccessMessage             string
 }
 
 func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) (err error) {
@@ -45,7 +47,14 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 		return fmt.Errorf("Error sending command to shell: %v", err)
 	}
 
-	commandReflection := fmt.Sprintf("$ %s", command)
+	var commandReflection string
+
+	if !t.SkipCurrentPromptAssertion {
+		commandReflection = fmt.Sprintf("$ %s", command)
+	} else {
+		commandReflection = command
+	}
+
 	asserter.AddAssertion(assertions.SingleLineAssertion{
 		ExpectedOutput: commandReflection,
 	})

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -29,9 +29,9 @@ type JobsBuiltinOutputEntry struct {
 
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []JobsBuiltinOutputEntry
-	// SkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the 'jobs' command reflection
-	SkipCurrentPromptAssertion bool
-	SuccessMessage             string
+	// ShouldSkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the 'jobs' command reflection
+	ShouldSkipCurrentPromptAssertion bool
+	SuccessMessage                   string
 }
 
 func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) (err error) {
@@ -49,7 +49,7 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 
 	var commandReflection string
 
-	if !t.SkipCurrentPromptAssertion {
+	if !t.ShouldSkipCurrentPromptAssertion {
 		commandReflection = fmt.Sprintf("$ %s", command)
 	} else {
 		commandReflection = command

--- a/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
+++ b/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
@@ -5,22 +5,24 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2376[0m
+[33m[your-program] [0m[0m[1] 2581[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q apple /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[2] 2377[0m
+[33m[your-program] [0m[0m$ grep apple /tmp/apple-80 &[0m
+[33m[your-program] [0m[0m[2] 2582[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q apple /tmp/blueberry-54 &[0m
-[33m[your-program] [0m[0m[3] 2378[0m
+[33m[your-program] [0m[0m$ grep apple /tmp/blueberry-54 &[0m
+[33m[your-program] [0m[0m[3] 2583[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "apple" > "/tmp/apple-80"[0m
-[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m$ apple[0m
+[33m[tester::#RQ2] [0m[92m✓ Output of 'grep apple /tmp/apple-80' found[0m
+[33m[your-program] [0m[0mjobs[0m
 [33m[your-program] [0m[0m[1]   Running                 sleep 500 &[0m
-[33m[your-program] [0m[0m[2]-  Running                 grep -q apple /tmp/apple-80 &[0m
+[33m[your-program] [0m[0m[2]-  Running                 grep apple /tmp/apple-80 &[0m
 [33m[tester::#RQ2] [0m[91m^ Line does not match expected value.[0m
-[33m[tester::#RQ2] [0m[91m[32mExpected:[0m "[2]-  Done                 grep -q apple /tmp/apple-80"[0m
-[33m[tester::#RQ2] [0m[91m[31mReceived:[0m "[2]-  Running                 grep -q apple /tmp/apple-80 &"[0m
-[33m[your-program] [0m[0m[3]+  Running                 grep -q apple /tmp/blueberry-54 &[0m
+[33m[tester::#RQ2] [0m[91m[32mExpected:[0m "[2]-  Done                 grep apple /tmp/apple-80"[0m
+[33m[tester::#RQ2] [0m[91m[31mReceived:[0m "[2]-  Running                 grep apple /tmp/apple-80 &"[0m
+[33m[your-program] [0m[0m[3]+  Running                 grep apple /tmp/blueberry-54 &[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#RQ2] [0m[91mAssertion failed.[0m
 [33m[tester::#RQ2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,7 +13,7 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2278[0m
+[33m[your-program] [0m[0m[1] 2693[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -21,7 +21,7 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2280[0m
+[33m[your-program] [0m[0m[1] 2695[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -32,20 +32,20 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2282[0m
+[33m[your-program] [0m[0m[1] 2697[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2283[0m
+[33m[your-program] [0m[0m[2] 2698[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2284[0m
+[33m[your-program] [0m[0m[3] 2699[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -58,15 +58,17 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning tests for Stage #MA9 (ma9)[0m
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
-[33m[your-program] [0m[0m$ grep -q raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2286[0m
+[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1] 2707[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
-[33m[your-program] [0m[0m[1]+  Running                    grep -q raspberry /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1]+  Running                    grep raspberry /tmp/pear-70 &[0m
 [33m[tester::#MA9] [0m[92m✓ 1 entry matches the running job[0m
 [33m[tester::#MA9] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
-[33m[your-program] [0m[0m$ jobs[0m
-[33m[your-program] [0m[0m[1]+  Done                       grep -q raspberry /tmp/pear-70[0m
+[33m[your-program] [0m[0m$ raspberry[0m
+[33m[tester::#MA9] [0m[92m✓ Output of background command 'grep' found[0m
+[33m[your-program] [0m[0mjobs[0m
+[33m[your-program] [0m[0m[1]+  Done                       grep raspberry /tmp/pear-70[0m
 [33m[tester::#MA9] [0m[92m✓ 1 entry matches the finished job[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#MA9] [0m[92mTest passed.[0m
@@ -76,24 +78,28 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/mango-16[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2289[0m
+[33m[your-program] [0m[0m[1] 2709[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q mango /tmp/blueberry-26 &[0m
-[33m[your-program] [0m[0m[2] 2290[0m
+[33m[your-program] [0m[0m$ grep mango /tmp/blueberry-26 &[0m
+[33m[your-program] [0m[0m[2] 2710[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep -q grape /tmp/mango-16 &[0m
-[33m[your-program] [0m[0m[3] 2291[0m
+[33m[your-program] [0m[0m$ grep grape /tmp/mango-16 &[0m
+[33m[your-program] [0m[0m[3] 2711[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "mango" > "/tmp/blueberry-26"[0m
-[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m$ mango[0m
+[33m[tester::#RQ2] [0m[92m✓ Output of 'grep mango /tmp/blueberry-26' found[0m
+[33m[your-program] [0m[0mjobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[2]-  Done                       grep -q mango /tmp/blueberry-26[0m
-[33m[your-program] [0m[0m[3]+  Running                    grep -q grape /tmp/mango-16 &[0m
+[33m[your-program] [0m[0m[2]-  Done                       grep mango /tmp/blueberry-26[0m
+[33m[your-program] [0m[0m[3]+  Running                    grep grape /tmp/mango-16 &[0m
 [33m[tester::#RQ2] [0m[92m✓ Received 3 entries in the output[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho "grape" > "/tmp/mango-16"[0m
-[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m$ grape[0m
+[33m[tester::#RQ2] [0m[92m✓ Output of 'grep grape /tmp/mango-16' found[0m
+[33m[your-program] [0m[0mjobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[3]+  Done                       grep -q grape /tmp/mango-16[0m
+[33m[your-program] [0m[0m[3]+  Done                       grep grape /tmp/mango-16[0m
 [33m[tester::#RQ2] [0m[92m✓ Received 2 entries in the output[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m

--- a/internal/test_helpers/scenarios/background_jobs_jobs_builtin_not_reaped/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_jobs_builtin_not_reaped/main.py
@@ -79,8 +79,6 @@ def run_external(args: list[str], background: bool = False) -> tuple[int | None,
             proc = subprocess.Popen(
                 [path] + args[1:],
                 env=os.environ,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
             return (None, proc)
         proc = subprocess.run(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes stage harness expectations around background-process stdout and prompt reflection, which can affect test stability and may fail previously-passing shells that handle prompt/output ordering differently.
> 
> **Overview**
> Stages `bg5`/`bg6` now run `grep` *without* `-q` and **assert that the background command’s stdout is actually printed** before continuing, via a new `BackgroundCommandOutputOnlyTestCase`.
> 
> To accommodate output interleaving, `JobsBuiltinResponseTestCase` adds `ShouldSkipCurrentPromptAssertion` so `jobs` can be asserted even when the usual `$ ` prompt reflection has been consumed by background output. The `background_jobs_jobs_builtin_not_reaped` scenario stops discarding background stdout/stderr so this output is observable, and fixtures/deps are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85b04417daae13d37f1ac1a198b4faae9aeca440. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->