### PR TITLE
Background Jobs Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,13 +175,13 @@ define _BACKGROUND_JOBS_STAGES
 [ \
 	{"slug":"af3","tester_log_prefix":"tester::#af3","title":"Stage#1: The jobs builtin"}, \
 	{"slug":"at7","tester_log_prefix":"tester::#at7","title":"Stage#2: Starting background jobs"}, \
-	{"slug":"si2","tester_log_prefix":"tester::#si2","title":"Stage#2: Printing background job output"}, \
-	{"slug":"jd6","tester_log_prefix":"tester::#jd6","title":"Stage#3: List a single job"}, \
-	{"slug":"dk5","tester_log_prefix":"tester::#dk5","title":"Stage#4: List multiple jobs"}, \
-	{"slug":"ma9","tester_log_prefix":"tester::#ma9","title":"Stage#5: Reaping one job using jobs"}, \
-	{"slug":"rq2","tester_log_prefix":"tester::#rq2","title":"Stage#6: Reaping multiple jobs using jobs"}, \
-	{"slug":"bv8","tester_log_prefix":"tester::#bv8","title":"Stage#7: Reap before the next prompt"}, \
-	{"slug":"fy4","tester_log_prefix":"tester::#fy4","title":"Stage#8: Job number reset"} \
+	{"slug":"si2","tester_log_prefix":"tester::#si2","title":"Stage#3: Printing background job output"}, \
+	{"slug":"jd6","tester_log_prefix":"tester::#jd6","title":"Stage#4: List a single job"}, \
+	{"slug":"dk5","tester_log_prefix":"tester::#dk5","title":"Stage#5: List multiple jobs"}, \
+	{"slug":"ma9","tester_log_prefix":"tester::#ma9","title":"Stage#6: Reaping one job using jobs"}, \
+	{"slug":"rq2","tester_log_prefix":"tester::#rq2","title":"Stage#7: Reaping multiple jobs using jobs"}, \
+	{"slug":"bv8","tester_log_prefix":"tester::#bv8","title":"Stage#8: Reap before the next prompt"}, \
+	{"slug":"fy4","tester_log_prefix":"tester::#fy4","title":"Stage#9: Job number reset"} \
 ]
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ define _BACKGROUND_JOBS_STAGES
 [ \
 	{"slug":"af3","tester_log_prefix":"tester::#af3","title":"Stage#1: The jobs builtin"}, \
 	{"slug":"at7","tester_log_prefix":"tester::#at7","title":"Stage#2: Starting background jobs"}, \
+	{"slug":"si2","tester_log_prefix":"tester::#si2","title":"Stage#2: Printing background job output"}, \
 	{"slug":"jd6","tester_log_prefix":"tester::#jd6","title":"Stage#3: List a single job"}, \
 	{"slug":"dk5","tester_log_prefix":"tester::#dk5","title":"Stage#4: List multiple jobs"}, \
 	{"slug":"ma9","tester_log_prefix":"tester::#ma9","title":"Stage#5: Reaping one job using jobs"}, \

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,9 @@ test_pipeline_w_bash: build
 test_background_jobs_w_bash: build
 	$(call run_test,$(BACKGROUND_JOBS_STAGES),bash)
 
+test_background_jobs_w_zsh: build
+	$(call run_test,$(BACKGROUND_JOBS_STAGES),zsh)
+
 test_base_w_dash: build
 	$(call run_test,$(BASE_STAGES),dash)
 
@@ -378,6 +381,7 @@ test_zsh:
 	make test_redirections_w_zsh
 	make test_completions_w_zsh
 	make test_filename_completion_w_zsh
+	make test_background_jobs_w_zsh
 	make test_history_w_zsh
 
 # Clone the repo in `debug` directory

--- a/Makefile
+++ b/Makefile
@@ -301,9 +301,6 @@ test_pipeline_w_bash: build
 test_background_jobs_w_bash: build
 	$(call run_test,$(BACKGROUND_JOBS_STAGES),bash)
 
-test_background_jobs_w_zsh: build
-	$(call run_test,$(BACKGROUND_JOBS_STAGES),zsh)
-
 test_base_w_dash: build
 	$(call run_test,$(BASE_STAGES),dash)
 
@@ -381,7 +378,6 @@ test_zsh:
 	make test_redirections_w_zsh
 	make test_completions_w_zsh
 	make test_filename_completion_w_zsh
-	make test_background_jobs_w_zsh
 	make test_history_w_zsh
 
 # Clone the repo in `debug` directory

--- a/internal/stage_bg2.go
+++ b/internal/stage_bg2.go
@@ -1,13 +1,9 @@
 package internal
 
 import (
-	"fmt"
-
-	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
-	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -20,37 +16,15 @@ func testBG2(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Create a named pipe
-	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
-		return err
-	}
-
-	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
+	bgSleepCommand := "sleep 500"
 
 	testCase := test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand,
+		Command:           bgSleepCommand,
 		SuccessMessage:    "✓ Received next prompt",
 		ExpectedJobNumber: 1,
 	}
 
 	if err := testCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Write to the fifo
-	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
-		return err
-	}
-
-	// Assert background command output
-	backgroundCommandOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found in the next prompt line", shellescape.Quote(bgGrepCommand)),
-	}
-
-	if err := backgroundCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -1,9 +1,15 @@
 package internal
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -16,30 +22,78 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Launch a program in the background
-	backgroundLaunchCommand := "sleep 100"
-	backgroundLaunchTestCase := test_cases.BackgroundCommandResponseTestCase{
-		Command:           backgroundLaunchCommand,
-		SuccessMessage:    "✓ Output includes job number with PID",
-		ExpectedJobNumber: 1,
-	}
+	// Create a named pipe
+	fifoBaseNames := random.RandomWords(2)
 
-	if err := backgroundLaunchTestCase.Run(asserter, shell, logger); err != nil {
+	fifoPath1 := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", fifoBaseNames[0], random.RandomInt(1, 100)),
+	)
+
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
 		return err
 	}
 
-	// Assert the job output
-	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
-			JobNumber:     1,
-			Status:        "Running",
-			LaunchCommand: backgroundLaunchCommand,
-			Marker:        test_cases.CurrentJob,
-		}},
-		SuccessMessage: "✓ 1 entry matches the running job",
+	fifoPath2 := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", fifoBaseNames[1], random.RandomInt(1, 100)),
+	)
+
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath2, 0644); err != nil {
+		return err
 	}
 
-	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
+	bgCatCommand := fmt.Sprintf("cat %s", fifoPath1)
+	bgCommandTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand,
+		SuccessMessage:    "✓ Received next prompt",
+		ExpectedJobNumber: 1,
+	}
+
+	if err := bgCommandTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Launch a foreground test case that reads from the fifo
+	fgCatCommand := fmt.Sprintf("cat %s", fifoPath2)
+	fgCommandTestCase := test_cases.CommandWithNoResponseTestCase{
+		Command:             fgCatCommand,
+		SkipPromptAssertion: true,
+	}
+
+	if err := fgCommandTestCase.Run(asserter, shell, logger, true); err != nil {
+		return err
+	}
+
+	// Write to the fifo 1, and assert the output
+	fifo1Contents := "Hello from FIFO #1\n"
+	if err := WriteToFile(stageHarness, fifoPath1, fifo1Contents); err != nil {
+		return err
+	}
+
+	// Assert background cat command output
+	backgroundCommandOutputTestCase := test_cases.OutputOnlyTestCase{
+		ExpectedOutputLines: []string{strings.TrimSuffix(fifo1Contents, "\n")},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgCatCommand)),
+	}
+
+	if err := backgroundCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write to the fifo 2, and assert the output
+	fifo2Contents := "Hello from FIFO #2\n"
+	if err := WriteToFile(stageHarness, fifoPath2, fifo2Contents); err != nil {
+		return err
+	}
+
+	// Assert foreground cat command output
+	foregroundCommandOutputTestCase := test_cases.OutputOnlyTestCase{
+		ExpectedOutputLines: []string{strings.TrimSuffix(fifo2Contents, "\n")},
+		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(fgCatCommand)),
+	}
+
+	if err := foregroundCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
-	"github.com/codecrafters-io/tester-utils/testing"
 )
 
 func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -89,6 +88,8 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	time.Sleep(time.Millisecond)
+
 	// Assert foreground cat command output
 	fgCommandOutputTestCase := test_cases.OutputOnlyTestCase{
 		ExpectedOutputLines: []string{strings.TrimSuffix(fifo2Contents, "\n")},
@@ -99,10 +100,6 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed in the fixtures
-	if testing.IsRecordingOrEvaluatingFixtures() {
-		time.Sleep(time.Second)
-	}
-
 	return logAndQuit(asserter, nil)
+
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -99,7 +99,7 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(time.Second)
 
 	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
+	"github.com/codecrafters-io/tester-utils/testing"
 )
 
 func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -98,8 +99,10 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed
-	time.Sleep(time.Second)
+	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed in the fixtures
+	if testing.IsRecordingOrEvaluatingFixtures() {
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -101,7 +101,7 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed in the fixtures
 	if testing.IsRecordingOrEvaluatingFixtures() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Second)
 	}
 
 	return logAndQuit(asserter, nil)

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -101,5 +101,4 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	return logAndQuit(asserter, nil)
-
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -96,6 +97,9 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := fgCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
+
+	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed
+	time.Sleep(time.Millisecond)
 
 	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -99,7 +99,7 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Sleep before logging so that the finished job status and prompt are guaranteed to be printed
-	time.Sleep(time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -72,12 +72,12 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Assert background cat command output
-	backgroundCommandOutputTestCase := test_cases.OutputOnlyTestCase{
+	bgCommandOutputTestCasae := test_cases.OutputOnlyTestCase{
 		ExpectedOutputLines: []string{strings.TrimSuffix(fifo1Contents, "\n")},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgCatCommand)),
+		SuccessMessage:      fmt.Sprintf("✓ Received output from background job %s", shellescape.Quote(bgCatCommand)),
 	}
 
-	if err := backgroundCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
+	if err := bgCommandOutputTestCasae.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
@@ -88,12 +88,12 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Assert foreground cat command output
-	foregroundCommandOutputTestCase := test_cases.OutputOnlyTestCase{
+	fgCommandOutputTestCase := test_cases.OutputOnlyTestCase{
 		ExpectedOutputLines: []string{strings.TrimSuffix(fifo2Contents, "\n")},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(fgCatCommand)),
+		SuccessMessage:      fmt.Sprintf("✓ Received output from foreground job %s", shellescape.Quote(fgCatCommand)),
 	}
 
-	if err := foregroundCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
+	if err := fgCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg4.go
+++ b/internal/stage_bg4.go
@@ -1,14 +1,10 @@
 package internal
 
 import (
-	"fmt"
-
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
-	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
-	"github.com/dustin/go-humanize/english"
 )
 
 func testBG4(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -20,72 +16,32 @@ func testBG4(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	commands := []string{"sleep 100", "sleep 200", "sleep 300"}
+	// Launch a program in the background
+	backgroundLaunchCommand := "sleep 100"
+	backgroundLaunchTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           backgroundLaunchCommand,
+		SuccessMessage:    "✓ Output includes job number with PID",
+		ExpectedJobNumber: 1,
+	}
 
-	if err := launchBgCommandAndAssertJobs(asserter, shell, logger, commands); err != nil {
+	if err := backgroundLaunchTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Assert the job output
+	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     1,
+			Status:        "Running",
+			LaunchCommand: backgroundLaunchCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ 1 entry matches the running job",
+	}
+
+	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
 	return logAndQuit(asserter, nil)
-}
-
-// launchBgCommandAndAssertJobs launches the given bgCommands one by one
-// with a 'jobs' call after each launch
-func launchBgCommandAndAssertJobs(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger, bgCommands []string) error {
-	type jobInfo struct {
-		JobNumber int
-		Command   string
-	}
-
-	var jobs []jobInfo
-
-	for i, bgCommand := range bgCommands {
-		backgroundLaunchTestCase := test_cases.BackgroundCommandResponseTestCase{
-			Command:           bgCommand,
-			SuccessMessage:    "✓ Output includes job number with PID",
-			ExpectedJobNumber: i + 1,
-		}
-
-		if err := backgroundLaunchTestCase.Run(asserter, shell, logger); err != nil {
-			return err
-		}
-
-		jobs = append(jobs, jobInfo{JobNumber: i + 1, Command: bgCommand})
-
-		jobsOutputEntries := make([]test_cases.BackgroundJobStatusEntry, 0, len(jobs))
-
-		for i, job := range jobs {
-			// Default marker is unmarked
-			marker := test_cases.UnmarkedJob
-
-			// If the job was recently launched, it is the 'Current' job
-			if i == len(jobs)-1 {
-				marker = test_cases.CurrentJob
-				// If the job was launched previously, it is the 'Previous' job
-			} else if i == len(jobs)-2 {
-				marker = test_cases.PreviousJob
-			}
-
-			jobsOutputEntries = append(jobsOutputEntries, test_cases.BackgroundJobStatusEntry{
-				JobNumber:     job.JobNumber,
-				Status:        "Running",
-				LaunchCommand: job.Command,
-				Marker:        marker,
-			})
-		}
-
-		jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
-			ExpectedOutputEntries: jobsOutputEntries,
-			SuccessMessage: fmt.Sprintf(
-				"✓ %s match the running %s",
-				english.Plural(len(jobsOutputEntries), "entry", "entries"),
-				english.PluralWord(len(jobsOutputEntries), "job", "jobs"),
-			),
-		}
-
-		if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/stage_bg5.go
+++ b/internal/stage_bg5.go
@@ -2,13 +2,13 @@ package internal
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
-	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
+	"github.com/dustin/go-humanize/english"
 )
 
 func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -20,72 +20,72 @@ func testBG5(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Launch a grep fifo
-	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
-		return err
-	}
+	commands := []string{"sleep 100", "sleep 200", "sleep 300"}
 
-	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
-
-	bgJobTestCase := test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand,
-		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}
-
-	if err := bgJobTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Call jobs
-	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
-			JobNumber:     1,
-			Status:        "Running",
-			LaunchCommand: bgGrepCommand,
-			Marker:        test_cases.CurrentJob,
-		}},
-		SuccessMessage: "✓ 1 entry matches the running job",
-	}
-
-	if err := jobsBuiltinTestCase1.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Write to fifo
-	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
-		return err
-	}
-
-	// A small delay since grep takes some time to process and exit
-	time.Sleep(time.Millisecond)
-
-	err := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern},
-		SuccessMessage:      "✓ Output of background command 'grep' found",
-	}.Run(asserter, shell, logger)
-
-	if err != nil {
-		return err
-	}
-
-	// Call jobs again
-	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
-			JobNumber:     1,
-			Status:        "Done",
-			LaunchCommand: bgGrepCommand,
-			Marker:        test_cases.CurrentJob,
-		}},
-		ShouldSkipCurrentPromptAssertion: true,
-		SuccessMessage:                   "✓ 1 entry matches the finished job",
-	}
-
-	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
+	if err := launchBgCommandAndAssertJobs(asserter, shell, logger, commands); err != nil {
 		return err
 	}
 
 	return logAndQuit(asserter, nil)
+}
+
+// launchBgCommandAndAssertJobs launches the given bgCommands one by one
+// with a 'jobs' call after each launch
+func launchBgCommandAndAssertJobs(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger, bgCommands []string) error {
+	type jobInfo struct {
+		JobNumber int
+		Command   string
+	}
+
+	var jobs []jobInfo
+
+	for i, bgCommand := range bgCommands {
+		backgroundLaunchTestCase := test_cases.BackgroundCommandResponseTestCase{
+			Command:           bgCommand,
+			SuccessMessage:    "✓ Output includes job number with PID",
+			ExpectedJobNumber: i + 1,
+		}
+
+		if err := backgroundLaunchTestCase.Run(asserter, shell, logger); err != nil {
+			return err
+		}
+
+		jobs = append(jobs, jobInfo{JobNumber: i + 1, Command: bgCommand})
+
+		jobsOutputEntries := make([]test_cases.BackgroundJobStatusEntry, 0, len(jobs))
+
+		for i, job := range jobs {
+			// Default marker is unmarked
+			marker := test_cases.UnmarkedJob
+
+			// If the job was recently launched, it is the 'Current' job
+			if i == len(jobs)-1 {
+				marker = test_cases.CurrentJob
+				// If the job was launched previously, it is the 'Previous' job
+			} else if i == len(jobs)-2 {
+				marker = test_cases.PreviousJob
+			}
+
+			jobsOutputEntries = append(jobsOutputEntries, test_cases.BackgroundJobStatusEntry{
+				JobNumber:     job.JobNumber,
+				Status:        "Running",
+				LaunchCommand: job.Command,
+				Marker:        marker,
+			})
+		}
+
+		jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
+			ExpectedOutputEntries: jobsOutputEntries,
+			SuccessMessage: fmt.Sprintf(
+				"✓ %s match the running %s",
+				english.Plural(len(jobsOutputEntries), "entry", "entries"),
+				english.PluralWord(len(jobsOutputEntries), "job", "jobs"),
+			),
+		}
+
+		if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -80,5 +80,14 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	jobsBuiltinTestCase3 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
+		SuccessMessage:        "✓ No jobs",
+	}
+
+	if err := jobsBuiltinTestCase3.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_bg6.go
+++ b/internal/stage_bg6.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -17,130 +17,66 @@ func testBG6(stageHarness *test_case_harness.TestCaseHarness) error {
 	shell := shell_executable.NewShellExecutable(stageHarness)
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
 
-	fifoBaseNames := random.RandomWords(2)
-	fifoPath1 := fmt.Sprintf("/tmp/%s-%d", fifoBaseNames[0], random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
-		return err
-	}
-
-	fifoPath2 := fmt.Sprintf("/tmp/%s-%d", fifoBaseNames[1], random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath2, 0644); err != nil {
-		return err
-	}
-
 	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
 		return err
 	}
 
-	// Launch "sleep 500"
-	sleepCommand := "sleep 500"
-	bgSleepTestCase := test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleepCommand,
+	fifoPath := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", random.RandomWord(), random.RandomInt(1, 100)),
+	)
+
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
+		return err
+	}
+
+	bgCatCommand := fmt.Sprintf("cat %s", fifoPath)
+
+	bgJobTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand,
 		ExpectedJobNumber: 1,
 		SuccessMessage:    "✓ Output includes job number with PID",
 	}
-	if err := bgSleepTestCase.Run(asserter, shell, logger); err != nil {
+
+	if err := bgJobTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	// Launch 'grep read pattern' to hang the process indefinitely
-
-	grepPattern1 := random.RandomWord()
-	bgGrepCommand1 := fmt.Sprintf("grep %s %s", grepPattern1, fifoPath1)
-	bgGrepTestCase1 := test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand1,
-		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}
-	if err := bgGrepTestCase1.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Launch grep read pattern again
-	grepPattern2 := random.RandomWord()
-	bgGrepCommand2 := fmt.Sprintf("grep %s %s", grepPattern2, fifoPath2)
-	bgGrepTestCase2 := test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand2,
-		ExpectedJobNumber: 3,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}
-
-	if err := bgGrepTestCase2.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// We write to the first fifo
-	if err := WriteToFile(stageHarness, fifoPath1, grepPattern1); err != nil {
-		return err
-	}
-
-	time.Sleep(time.Millisecond)
-
-	// Assert the background command's output
-	err := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern1},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand1)),
-	}.Run(asserter, shell, logger)
-
-	if err != nil {
-		return err
-	}
-
-	// Call jobs for the first time
+	// Call jobs
 	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.UnmarkedJob},
-			{JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.PreviousJob},
-			{JobNumber: 3, Status: "Running", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
-		},
-		// Because background command will have consumed the prompt line
-		ShouldSkipCurrentPromptAssertion: true,
-		SuccessMessage:                   "✓ Received 3 entries in the output",
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     1,
+			Status:        "Running",
+			LaunchCommand: bgCatCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ 1 entry matches the running job",
 	}
 
 	if err := jobsBuiltinTestCase1.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	// Write to the second fifo
-	if err := WriteToFile(stageHarness, fifoPath2, grepPattern2); err != nil {
+	// Write empty string to the FIFO
+	if err := WriteToFile(stageHarness, fifoPath, ""); err != nil {
 		return err
 	}
 
+	// A small delay since cat takes some time to process and exit
 	time.Sleep(time.Millisecond)
 
-	// Assert the background command's output
-	err = test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern2},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand2)),
-	}.Run(asserter, shell, logger)
-
-	if err != nil {
-		return err
-	}
-
-	// Call jobs for the second time
-	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
-			{JobNumber: 3, Status: "Done", LaunchCommand: bgGrepCommand2, Marker: test_cases.CurrentJob},
-		},
-		// Prompt will have been consumed by the background command output
-		ShouldSkipCurrentPromptAssertion: true,
-		SuccessMessage:                   "✓ Received 2 entries in the output",
-	}
-	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
 	// Call jobs again
-	jobsBuiltinTestCase3 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob},
-		},
-		SuccessMessage: "✓ 1 entry matches the running job",
+	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     1,
+			Status:        "Done",
+			LaunchCommand: bgCatCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ 1 entry matches the finished job",
 	}
-	if err := jobsBuiltinTestCase3.Run(asserter, shell, logger); err != nil {
+
+	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg7.go
+++ b/internal/stage_bg7.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"fmt"
+	"path/filepath"
+	"time"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -16,8 +17,21 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 	shell := shell_executable.NewShellExecutable(stageHarness)
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
 
-	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
+	fifoBaseNames := random.RandomWords(2)
+	fifoPath1 := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", fifoBaseNames[0], random.RandomInt(1, 100)),
+	)
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
+		return err
+	}
+
+	fifoPath2 := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", fifoBaseNames[1], random.RandomInt(1, 100)),
+	)
+
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath2, 0644); err != nil {
 		return err
 	}
 
@@ -25,7 +39,7 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Spawn background process: sleep 500
+	// Launch "sleep 500"
 	sleepCommand := "sleep 500"
 	bgSleepTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand,
@@ -36,75 +50,77 @@ func testBG7(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Grep read pattern
-	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
-	bgGrepTestCase := test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand,
+	// Launch 'cat read pattern' to hang the process indefinitely
+	bgCatCommand1 := fmt.Sprintf("cat %s", fifoPath1)
+	bgCatTestCase1 := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand1,
 		ExpectedJobNumber: 2,
 		SuccessMessage:    "✓ Output includes job number with PID",
 	}
-	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
+	if err := bgCatTestCase1.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	// Run jobs
-	jobsBuiltinTestCase := test_cases.JobsBuiltinResponseTestCase{
+	// Launch cat that reads from the fifo
+	bgCatCommand2 := fmt.Sprintf("cat %s", fifoPath2)
+	bgCatTestCase2 := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand2,
+		ExpectedJobNumber: 3,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}
+
+	if err := bgCatTestCase2.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write an empty string to the first fifo
+	if err := WriteToFile(stageHarness, fifoPath1, ""); err != nil {
+		return err
+	}
+
+	time.Sleep(time.Millisecond)
+
+	// Call jobs for the first time
+	jobsBuiltinTestCase1 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.UnmarkedJob},
+			{JobNumber: 2, Status: "Done", LaunchCommand: bgCatCommand1, Marker: test_cases.PreviousJob},
+			{JobNumber: 3, Status: "Running", LaunchCommand: bgCatCommand2, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Received 3 entries in the output",
+	}
+
+	if err := jobsBuiltinTestCase1.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write empty string to the second fifo
+	if err := WriteToFile(stageHarness, fifoPath2, ""); err != nil {
+		return err
+	}
+
+	time.Sleep(time.Millisecond)
+
+	// Call jobs for the second time
+	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
 		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
 			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
-			{JobNumber: 2, Status: "Running", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob},
+			{JobNumber: 3, Status: "Done", LaunchCommand: bgCatCommand2, Marker: test_cases.CurrentJob},
 		},
-		SuccessMessage: "✓ Found 2 entries for the running jobs",
-	}
-	if err := jobsBuiltinTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Write to fifo
-	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
-		return err
-	}
-
-	// Background output test case
-	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand)),
-	}
-
-	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Issue an echo command and expect the reaped job entry will follow the echoed text
-	echoArgument := random.RandomWord()
-	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
-		Command:                          fmt.Sprintf("echo %s", echoArgument),
-		ExpectedCommandOutput:            echoArgument,
-		ShouldSkipCurrentPromptAssertion: true,
-		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
-			JobNumber:     2,
-			Status:        "Done",
-			LaunchCommand: bgGrepCommand,
-			Marker:        test_cases.CurrentJob,
-		}},
-		SuccessMessage: "✓ Found command output followed by an entry for the reaped job",
-	}
-
-	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Call jobs — only sleep (job 1) remains
-	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
-			JobNumber:     1,
-			Status:        "Running",
-			LaunchCommand: sleepCommand,
-			Marker:        test_cases.CurrentJob,
-		}},
-		SuccessMessage: "✓ 1 entry matches the running job",
+		SuccessMessage: "✓ Received 2 entries in the output",
 	}
 	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Call jobs again
+	jobsBuiltinTestCase3 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ 1 entry matches the running job",
+	}
+	if err := jobsBuiltinTestCase3.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg8.go
+++ b/internal/stage_bg8.go
@@ -2,9 +2,8 @@ package internal
 
 import (
 	"fmt"
-	"time"
+	"path/filepath"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
@@ -14,122 +13,14 @@ import (
 
 func testBG8(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger := stageHarness.Logger
-
-	if err := testBg8ResetToZero(stageHarness); err != nil {
-		return err
-	}
-
-	logger.Infof("Tearing down shell")
-
-	return testBg8Recycle(stageHarness)
-}
-
-func testBg8ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
 	shell := shell_executable.NewShellExecutable(stageHarness)
 	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
-	logger := stageHarness.Logger
 
-	fifoPath1 := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
-	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
-		return err
-	}
+	fifoPath := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", random.RandomWord(), random.RandomInt(1, 100)),
+	)
 
-	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
-		return err
-	}
-
-	grepPattern1 := random.RandomWord()
-	bgGrepCommand1 := fmt.Sprintf("grep %s %s", grepPattern1, fifoPath1)
-	bgGrepTestCase := &test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand1,
-		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}
-	if err := bgGrepTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Write to fifo to make job 1 'Done'
-	if err := WriteToFile(stageHarness, fifoPath1, grepPattern1); err != nil {
-		return err
-	}
-
-	time.Sleep(time.Millisecond)
-
-	// Background output test case for grep
-	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern1},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand1)),
-	}
-
-	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	echoArgs := random.RandomWords(2)
-	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
-		Command:               fmt.Sprintf("echo %s", echoArgs[0]),
-		ExpectedCommandOutput: echoArgs[0],
-		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Done", LaunchCommand: bgGrepCommand1, Marker: test_cases.CurrentJob},
-		},
-		ShouldSkipCurrentPromptAssertion: true,
-		SuccessMessage:                   "✓ Received output for echo followed by an entry for the reaped job",
-	}
-
-	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	// Test command output not followed by reaped jobs entry
-	echoTestCase2 := test_cases.CommandResponseTestCase{
-		Command:        fmt.Sprintf("echo %s", echoArgs[1]),
-		ExpectedOutput: echoArgs[1],
-		SuccessMessage: "✓ Received output for echo",
-	}
-
-	if err := echoTestCase2.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	jobsEmptyTestCase := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
-		SuccessMessage:        "✓ No jobs",
-	}
-
-	if err := jobsEmptyTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	sleepCommand := "sleep 10"
-	if err := (&test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleepCommand,
-		ExpectedJobNumber: 1,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}).Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	jobsOneEntryTestCase := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
-			JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob,
-		}},
-		SuccessMessage: "✓ 1 entry matches the running job",
-	}
-
-	if err := jobsOneEntryTestCase.Run(asserter, shell, logger); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
-	shell := shell_executable.NewShellExecutable(stageHarness)
-	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
-	logger := stageHarness.Logger
-
-	fifoPath := fmt.Sprintf("/tmp/%s-%d", random.RandomWord(), random.RandomInt(1, 100))
 	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
 		return err
 	}
@@ -138,74 +29,74 @@ func testBg8Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	sleepCommand := "sleep 100"
-	sleepCommandTestCase := &test_cases.BackgroundCommandResponseTestCase{
+	// Spawn background process: sleep 500
+	sleepCommand := "sleep 500"
+	bgSleepTestCase := test_cases.BackgroundCommandResponseTestCase{
 		Command:           sleepCommand,
 		ExpectedJobNumber: 1,
 		SuccessMessage:    "✓ Output includes job number with PID",
 	}
-	if err := sleepCommandTestCase.Run(asserter, shell, logger); err != nil {
+	if err := bgSleepTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	grepPattern := random.RandomWord()
-	bgGrepCommand := fmt.Sprintf("grep %s %s", grepPattern, fifoPath)
-	if err := (&test_cases.BackgroundCommandResponseTestCase{
-		Command:           bgGrepCommand,
+	// Cat read pattern
+	bgCatCommand := fmt.Sprintf("cat %s", fifoPath)
+	bgCatTestCase := test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand,
 		ExpectedJobNumber: 2,
 		SuccessMessage:    "✓ Output includes job number with PID",
-	}).Run(asserter, shell, logger); err != nil {
+	}
+	if err := bgCatTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	if err := WriteToFile(stageHarness, fifoPath, grepPattern); err != nil {
-		return err
+	// Run jobs
+	jobsBuiltinTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: bgCatCommand, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Found 2 entries for the running jobs",
 	}
-	time.Sleep(time.Millisecond)
-
-	// Background output test case for grep
-
-	backgroundOutputTestCase := test_cases.BackgroundCommandOutputOnlyTestCase{
-		ExpectedOutputLines: []string{grepPattern},
-		SuccessMessage:      fmt.Sprintf("✓ Output of %s found", shellescape.Quote(bgGrepCommand)),
-	}
-
-	if err := backgroundOutputTestCase.Run(asserter, shell, logger); err != nil {
+	if err := jobsBuiltinTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
+	// Write an empty string to FIFO
+	if err := WriteToFile(stageHarness, fifoPath, ""); err != nil {
+		return err
+	}
+
+	// Issue an echo command and expect the reaped job entry will follow the echoed text
 	echoArgument := random.RandomWord()
 	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
 		Command:               fmt.Sprintf("echo %s", echoArgument),
 		ExpectedCommandOutput: echoArgument,
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
-			JobNumber: 2, Status: "Done", LaunchCommand: bgGrepCommand, Marker: test_cases.CurrentJob,
+			JobNumber:     2,
+			Status:        "Done",
+			LaunchCommand: bgCatCommand,
+			Marker:        test_cases.CurrentJob,
 		}},
-		ShouldSkipCurrentPromptAssertion: true,
-		SuccessMessage:                   "✓ Received output for echo followed by an entry for the reaped job",
+		SuccessMessage: "✓ Found command output followed by an entry for the reaped job",
 	}
+
 	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	sleepCommand2 := "sleep 50"
-	if err := (&test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleepCommand2,
-		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Output includes job number with PID",
-	}).Run(asserter, shell, logger); err != nil {
-		return err
+	// Call jobs — only sleep (job 1) remains
+	jobsBuiltinTestCase2 := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber:     1,
+			Status:        "Running",
+			LaunchCommand: sleepCommand,
+			Marker:        test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ 1 entry matches the running job",
 	}
-
-	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
-		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
-			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.CurrentJob},
-		},
-		SuccessMessage: "✓ 2 entries match the running jobs",
-	}
-
-	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
+	if err := jobsBuiltinTestCase2.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_bg9.go
+++ b/internal/stage_bg9.go
@@ -1,0 +1,196 @@
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testBG9(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+
+	if err := testBg9ResetToZero(stageHarness); err != nil {
+		return err
+	}
+
+	logger.Infof("Tearing down shell")
+
+	return testBg9Recycle(stageHarness)
+}
+
+func testBg9ResetToZero(stageHarness *test_case_harness.TestCaseHarness) error {
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	logger := stageHarness.Logger
+
+	fifoPath1 := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", random.RandomWord(), random.RandomInt(1, 100)),
+	)
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath1, 0644); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	bgCatCommand1 := fmt.Sprintf("cat %s", fifoPath1)
+	bgCatTestCase := &test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand1,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}
+
+	if err := bgCatTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Write empty string to FIFO to make job 1 'Done'
+	if err := WriteToFile(stageHarness, fifoPath1, ""); err != nil {
+		return err
+	}
+
+	time.Sleep(time.Millisecond)
+
+	echoArgs := random.RandomWords(2)
+	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
+		Command:               fmt.Sprintf("echo %s", echoArgs[0]),
+		ExpectedCommandOutput: echoArgs[0],
+		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Done", LaunchCommand: bgCatCommand1, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
+	}
+
+	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Test command output not followed by reaped jobs entry
+	echoTestCase2 := test_cases.CommandResponseTestCase{
+		Command:        fmt.Sprintf("echo %s", echoArgs[1]),
+		ExpectedOutput: echoArgs[1],
+		SuccessMessage: "✓ Received output for echo",
+	}
+
+	if err := echoTestCase2.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsEmptyTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{},
+		SuccessMessage:        "✓ No jobs",
+	}
+
+	if err := jobsEmptyTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	sleepCommand := "sleep 10"
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsOneEntryTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{{
+			JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ 1 entry matches the running job",
+	}
+
+	if err := jobsOneEntryTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testBg9Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	logger := stageHarness.Logger
+
+	fifoPath := filepath.Join(
+		"/tmp",
+		fmt.Sprintf("%s-%d", random.RandomWord(), random.RandomInt(1, 100)),
+	)
+
+	if err := CreateRandomFIFOWithTeardown(stageHarness, fifoPath, 0644); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	sleepCommand := "sleep 100"
+	sleepCommandTestCase := &test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand,
+		ExpectedJobNumber: 1,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}
+	if err := sleepCommandTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	bgCatCommand := fmt.Sprintf("cat %s", fifoPath)
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           bgCatCommand,
+		ExpectedJobNumber: 2,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	if err := WriteToFile(stageHarness, fifoPath, ""); err != nil {
+		return err
+	}
+	time.Sleep(time.Millisecond)
+
+	echoArgument := random.RandomWord()
+	echoTestCase := test_cases.CommandResponseWithReapedJobsTestCase{
+		Command:               fmt.Sprintf("echo %s", echoArgument),
+		ExpectedCommandOutput: echoArgument,
+		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
+			JobNumber: 2, Status: "Done", LaunchCommand: bgCatCommand, Marker: test_cases.CurrentJob,
+		}},
+		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
+	}
+	if err := echoTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	sleepCommand2 := "sleep 50"
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand2,
+		ExpectedJobNumber: 2,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
+		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.CurrentJob},
+		},
+		SuccessMessage: "✓ 2 entries match the running jobs",
+	}
+
+	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -98,7 +98,7 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"background_jobs_pass_bash": {
-			StageSlugs:          []string{"af3", "at7", "jd6", "dk5", "ma9", "rq2", "bv8", "fy4"},
+			StageSlugs:          []string{"af3", "at7", "si2", "jd6", "dk5", "ma9", "rq2", "bv8", "fy4"},
 			CodePath:            "./test_helpers/bash",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/bash/background_jobs/pass",

--- a/internal/test_cases/command_response_with_reaped_jobs_test_case.go
+++ b/internal/test_cases/command_response_with_reaped_jobs_test_case.go
@@ -25,10 +25,6 @@ type CommandResponseWithReapedJobsTestCase struct {
 
 	// ExpectedReapedJobEntries is the list of entries expected after the command output appears
 	ExpectedReapedJobEntries []*BackgroundJobStatusEntry
-
-	// ShouldSkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the command reflection
-	// This is usually true when a background command's output has consumed the current prompt line
-	ShouldSkipCurrentPromptAssertion bool
 }
 
 func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
@@ -58,8 +54,7 @@ func (t CommandResponseWithReapedJobsTestCase) Run(asserter *logged_shell_assert
 		MultiLineAssertion: assertions.MultiLineAssertion{
 			SingleLineAssertions: allSingleLinesAssertion,
 		},
-		ShouldSkipCurrentPromptAssertion: t.ShouldSkipCurrentPromptAssertion,
-		SuccessMessage:                   t.SuccessMessage,
+		SuccessMessage: t.SuccessMessage,
 	}
 
 	if err := commandWithMultilineResponseTestCase.Run(asserter, shell, logger); err != nil {

--- a/internal/test_cases/command_with_multiline_response_test_case.go
+++ b/internal/test_cases/command_with_multiline_response_test_case.go
@@ -19,9 +19,6 @@ type CommandWithMultilineResponseTestCase struct {
 	// SuccessMessage is the message to log in case of success
 	SuccessMessage string
 
-	// ShouldSkipCurrentPromptAssertion should be set if prompt is not expected in the command reflection
-	ShouldSkipCurrentPromptAssertion bool
-
 	// ShouldSkipNextPromptAssertion is a flag to indicate that the prompt should not be asserted
 	ShouldSkipNextPromptAssertion bool
 }
@@ -31,13 +28,7 @@ func (t CommandWithMultilineResponseTestCase) Run(asserter *logged_shell_asserte
 		return fmt.Errorf("Error sending command to shell: %v", err)
 	}
 
-	var commandReflection string
-
-	if t.ShouldSkipCurrentPromptAssertion {
-		commandReflection = t.Command
-	} else {
-		commandReflection = fmt.Sprintf("$ %s", t.Command)
-	}
+	commandReflection := fmt.Sprintf("$ %s", t.Command)
 
 	asserter.AddAssertion(assertions.SingleLineAssertion{
 		ExpectedOutput: commandReflection,

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -80,9 +80,7 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 		return fmt.Errorf("Error sending command to shell: %v", err)
 	}
 
-	var commandReflection string
-
-	commandReflection = fmt.Sprintf("$ %s", command)
+	commandReflection := fmt.Sprintf("$ %s", command)
 
 	asserter.AddAssertion(assertions.SingleLineAssertion{
 		ExpectedOutput: commandReflection,

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -64,9 +64,7 @@ func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Rege
 
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []BackgroundJobStatusEntry
-	// ShouldSkipCurrentPromptAssertion should be set to true if the prompt symbol is not expected in the 'jobs' command reflection
-	ShouldSkipCurrentPromptAssertion bool
-	SuccessMessage                   string
+	SuccessMessage        string
 }
 
 func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) (err error) {
@@ -84,11 +82,7 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 
 	var commandReflection string
 
-	if !t.ShouldSkipCurrentPromptAssertion {
-		commandReflection = fmt.Sprintf("$ %s", command)
-	} else {
-		commandReflection = command
-	}
+	commandReflection = fmt.Sprintf("$ %s", command)
 
 	asserter.AddAssertion(assertions.SingleLineAssertion{
 		ExpectedOutput: commandReflection,

--- a/internal/test_cases/output_only_test_case.go
+++ b/internal/test_cases/output_only_test_case.go
@@ -1,32 +1,25 @@
 package test_cases
 
 import (
-	"fmt"
-
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-type BackgroundCommandOutputOnlyTestCase struct {
+// OutputOnlyTestCase should be used when no input is to be sent to the shell
+// but output is expected (due to a side effect of writing to a file) from a running foreground/background process
+type OutputOnlyTestCase struct {
 	ExpectedOutputLines []string
 	SuccessMessage      string
 }
 
-func (t BackgroundCommandOutputOnlyTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+func (t OutputOnlyTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
 	if len(t.ExpectedOutputLines) == 0 {
 		panic("Codecrafters Internal Error - ExpectedOutputLines is empty in BackgroundCommandOutputOnlyTestCase")
 	}
 
-	outputInPromptLine := t.ExpectedOutputLines[0]
-
-	promptLineReflection := fmt.Sprintf("$ %s", outputInPromptLine)
-	asserter.AddAssertion(assertions.SingleLineAssertion{
-		ExpectedOutput: promptLineReflection,
-	})
-
-	remainingOutputLinesAssertion := assertions.NewMultiLineAssertion(t.ExpectedOutputLines[1:])
+	remainingOutputLinesAssertion := assertions.NewMultiLineAssertion(t.ExpectedOutputLines)
 	asserter.AddAssertion(&remainingOutputLinesAssertion)
 
 	if err := asserter.AssertWithoutPrompt(); err != nil {

--- a/internal/test_cases/output_only_test_case.go
+++ b/internal/test_cases/output_only_test_case.go
@@ -19,8 +19,8 @@ func (t OutputOnlyTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsser
 		panic("Codecrafters Internal Error - ExpectedOutputLines is empty in BackgroundCommandOutputOnlyTestCase")
 	}
 
-	remainingOutputLinesAssertion := assertions.NewMultiLineAssertion(t.ExpectedOutputLines)
-	asserter.AddAssertion(&remainingOutputLinesAssertion)
+	outputLinesAssertion := assertions.NewMultiLineAssertion(t.ExpectedOutputLines)
+	asserter.AddAssertion(&outputLinesAssertion)
 
 	if err := asserter.AssertWithoutPrompt(); err != nil {
 		return err

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -1259,6 +1259,13 @@ stages:
     marketing_md: |-
       In this stage, you'll implement launching commands in the background.
 
+  - slug: "si2"
+    primary_extension_slug: "background-jobs"
+    name: "Printing background job output"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll implement wiring up background job's output streams to the terminal.
+
   - slug: "jd6"
     primary_extension_slug: "background-jobs"
     name: "List a single job"

--- a/internal/test_helpers/fixtures/background_jobs_incorrect_job_number
+++ b/internal/test_helpers/fixtures/background_jobs_incorrect_job_number
@@ -2,11 +2,10 @@ Debug = true
 
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_program.sh[0m
-[33m[tester::#AT7] [setup] [0m[94mmkfifo /tmp/pear-70[0m
-[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[0] 3003[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
+[33m[your-program] [0m[0m[0] 2785[0m
 [33m[tester::#AT7] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#AT7] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#AT7] [0m[91m[31mReceived:[0m "[0] 3003"[0m
+[33m[tester::#AT7] [0m[91m[31mReceived:[0m "[0] 2785"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_incorrect_output_format
+++ b/internal/test_helpers/fixtures/background_jobs_incorrect_output_format
@@ -2,11 +2,10 @@ Debug = true
 
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_program.sh[0m
-[33m[tester::#AT7] [setup] [0m[94mmkfifo /tmp/pear-70[0m
-[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1]2497[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
+[33m[your-program] [0m[0m[1]2551[0m
 [33m[tester::#AT7] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#AT7] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#AT7] [0m[91m[31mReceived:[0m "[1]2497"[0m
+[33m[tester::#AT7] [0m[91m[31mReceived:[0m "[1]2551"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_incorrect_pid
+++ b/internal/test_helpers/fixtures/background_jobs_incorrect_pid
@@ -2,8 +2,7 @@ Debug = true
 
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_program.sh[0m
-[33m[tester::#AT7] [setup] [0m[94mmkfifo /tmp/pear-70[0m
-[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
 [33m[your-program] [0m[0m[1] 1234[0m
 [33m[tester::#AT7] [0m[91mCould not find process with PID 1234[0m
 [33m[tester::#AT7] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
+++ b/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
@@ -3,16 +3,14 @@ Debug = true
 [33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_program.sh[0m
-[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2217[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2217[0m
+[33m[your-program] [0m[0m$ cat /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1] 2554[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2554[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
-[33m[tester::#FY4] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
-[33m[your-program] [0m[0m$ raspberry[0m
-[33m[tester::#FY4] [0m[92m✓ Output of 'grep raspberry /tmp/pear-70' found[0m
-[33m[your-program] [0m[0mecho blueberry[0m
-[33m[your-program] [0m[0mblueberry[0m
-[33m[your-program] [0m[0m[1]+ Done                    grep raspberry /tmp/pear-70[0m
+[33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/pear-70"[0m
+[33m[your-program] [0m[0m$ echo orange[0m
+[33m[your-program] [0m[0morange[0m
+[33m[your-program] [0m[0m[1]+ Done                    cat /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ echo mango[0m
 [33m[your-program] [0m[0mmango[0m
@@ -20,9 +18,9 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[2] 2221[0m
+[33m[your-program] [0m[0m[2] 2561[0m
 [33m[tester::#FY4] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#FY4] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2221"[0m
+[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2561"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#FY4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
+++ b/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
@@ -5,26 +5,24 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2679[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2679[0m
+[33m[your-program] [0m[0m[1] 2428[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2428[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep apple /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[2] 2681[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2681[0m
+[33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
+[33m[your-program] [0m[0m[2] 2430[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2430[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep apple /tmp/blueberry-54 &[0m
-[33m[your-program] [0m[0m[3] 2684[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2684[0m
+[33m[your-program] [0m[0m$ cat /tmp/blueberry-54 &[0m
+[33m[your-program] [0m[0m[3] 2432[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2432[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[tester::#RQ2] [setup] [0m[94mecho "apple" > "/tmp/apple-80"[0m
-[33m[your-program] [0m[0m$ apple[0m
-[33m[tester::#RQ2] [0m[92m✓ Output of 'grep apple /tmp/apple-80' found[0m
-[33m[your-program] [0m[0mjobs[0m
+[33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/apple-80"[0m
+[33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                 sleep 500 &[0m
-[33m[your-program] [0m[0m[2]-  Running                 grep apple /tmp/apple-80 &[0m
+[33m[your-program] [0m[0m[2]-  Running                 cat /tmp/apple-80 &[0m
 [33m[tester::#RQ2] [0m[91m^ Line does not match expected value.[0m
-[33m[tester::#RQ2] [0m[91m[32mExpected:[0m "[2]-  Done                 grep apple /tmp/apple-80"[0m
-[33m[tester::#RQ2] [0m[91m[31mReceived:[0m "[2]-  Running                 grep apple /tmp/apple-80 &"[0m
-[33m[your-program] [0m[0m[3]+  Running                 grep apple /tmp/blueberry-54 &[0m
+[33m[tester::#RQ2] [0m[91m[32mExpected:[0m "[2]-  Done                 cat /tmp/apple-80"[0m
+[33m[tester::#RQ2] [0m[91m[31mReceived:[0m "[2]-  Running                 cat /tmp/apple-80 &"[0m
+[33m[your-program] [0m[0m[3]+  Running                 cat /tmp/blueberry-54 &[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#RQ2] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2731[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2731[0m
+[33m[your-program] [0m[0m[1] 2447[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2447[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,16 +24,16 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2734[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2734[0m
+[33m[your-program] [0m[0m[1] 2450[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2450[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #1\n" > "/tmp/apple-80"[0m
 [33m[your-program] [0m[0mHello from FIFO #1[0m
-[33m[tester::#SI2] [0m[92m✓ Output of 'cat /tmp/apple-80' found[0m
+[33m[tester::#SI2] [0m[92m✓ Received output from background job 'cat /tmp/apple-80'[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #2\n" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
-[33m[tester::#SI2] [0m[92m✓ Output of 'cat /tmp/blueberry-54' found[0m
+[33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
 [33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
@@ -41,8 +41,8 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2741[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2741[0m
+[33m[your-program] [0m[0m[1] 2454[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2454[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -53,23 +53,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2744[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2744[0m
+[33m[your-program] [0m[0m[1] 2457[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2457[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2746[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2746[0m
+[33m[your-program] [0m[0m[2] 2459[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2459[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2748[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2748[0m
+[33m[your-program] [0m[0m[3] 2461[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2461[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -83,8 +83,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2751[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2751[0m
+[33m[your-program] [0m[0m[1] 2466[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2466[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -93,6 +93,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-26[0m
 [33m[tester::#MA9] [0m[92m✓ 1 entry matches the finished job[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[tester::#MA9] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#MA9] [0m[92mTest passed.[0m
 
@@ -101,16 +103,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2754[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2754[0m
+[33m[your-program] [0m[0m[1] 2471[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2471[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2756[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2756[0m
+[33m[your-program] [0m[0m[2] 2473[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2473[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2758[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2758[0m
+[33m[your-program] [0m[0m[3] 2475[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2475[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -133,12 +135,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2763[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2763[0m
+[33m[your-program] [0m[0m[1] 2480[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2480[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2766[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2766[0m
+[33m[your-program] [0m[0m[2] 2482[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2482[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -159,8 +161,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2769[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2769[0m
+[33m[your-program] [0m[0m[1] 2485[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2485[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -173,8 +175,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2771[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2771[0m
+[33m[your-program] [0m[0m[1] 2487[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2487[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -183,12 +185,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2774[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2774[0m
+[33m[your-program] [0m[0m[1] 2490[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2490[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2776[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2776[0m
+[33m[your-program] [0m[0m[2] 2492[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2492[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -196,8 +198,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2778[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2778[0m
+[33m[your-program] [0m[0m[2] 2494[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2494[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2881[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2881[0m
+[33m[your-program] [0m[0m[1] 2190[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2190[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2884[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2884[0m
+[33m[your-program] [0m[0m[1] 2193[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2193[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -34,15 +34,13 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
-[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
-[33m[your-program] [0m[0m$ [0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2888[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2888[0m
+[33m[your-program] [0m[0m[1] 2197[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2197[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -53,23 +51,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2891[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2891[0m
+[33m[your-program] [0m[0m[1] 2200[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2200[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2893[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2893[0m
+[33m[your-program] [0m[0m[2] 2202[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2202[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2895[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2895[0m
+[33m[your-program] [0m[0m[3] 2205[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2205[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -83,8 +81,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2898[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2898[0m
+[33m[your-program] [0m[0m[1] 2208[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2208[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -103,16 +101,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2901[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2901[0m
+[33m[your-program] [0m[0m[1] 2213[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2213[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2903[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2903[0m
+[33m[your-program] [0m[0m[2] 2215[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2215[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2905[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2905[0m
+[33m[your-program] [0m[0m[3] 2217[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2217[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -135,12 +133,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2908[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2908[0m
+[33m[your-program] [0m[0m[1] 2221[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2221[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2910[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2910[0m
+[33m[your-program] [0m[0m[2] 2223[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2223[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -161,8 +159,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2913[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2913[0m
+[33m[your-program] [0m[0m[1] 2228[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2228[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -175,8 +173,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2915[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2915[0m
+[33m[your-program] [0m[0m[1] 2230[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2230[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -185,12 +183,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2918[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2918[0m
+[33m[your-program] [0m[0m[1] 2233[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2233[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2920[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2920[0m
+[33m[your-program] [0m[0m[2] 2235[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2235[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -198,8 +196,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2922[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2922[0m
+[33m[your-program] [0m[0m[2] 2237[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2237[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2447[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2447[0m
+[33m[your-program] [0m[0m[1] 2881[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2881[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,14 +24,14 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2450[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2450[0m
+[33m[your-program] [0m[0m[1] 2884[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2884[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
-[33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #1\n" > "/tmp/apple-80"[0m
+[33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
 [33m[your-program] [0m[0mHello from FIFO #1[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from background job 'cat /tmp/apple-80'[0m
-[33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #2\n" > "/tmp/blueberry-54"[0m
+[33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
 [33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
@@ -41,8 +41,8 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2454[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2454[0m
+[33m[your-program] [0m[0m[1] 2888[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2888[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -53,23 +53,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2457[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2457[0m
+[33m[your-program] [0m[0m[1] 2891[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2891[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2459[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2459[0m
+[33m[your-program] [0m[0m[2] 2893[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2893[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2461[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2461[0m
+[33m[your-program] [0m[0m[3] 2895[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2895[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -83,8 +83,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2466[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2466[0m
+[33m[your-program] [0m[0m[1] 2898[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2898[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -103,16 +103,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2471[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2471[0m
+[33m[your-program] [0m[0m[1] 2901[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2901[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2473[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2473[0m
+[33m[your-program] [0m[0m[2] 2903[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2903[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2475[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2475[0m
+[33m[your-program] [0m[0m[3] 2905[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2905[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -135,12 +135,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2480[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2480[0m
+[33m[your-program] [0m[0m[1] 2908[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2908[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2482[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2482[0m
+[33m[your-program] [0m[0m[2] 2910[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2910[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -161,8 +161,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2485[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2485[0m
+[33m[your-program] [0m[0m[1] 2913[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2913[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -175,8 +175,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2487[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2487[0m
+[33m[your-program] [0m[0m[1] 2915[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2915[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -185,12 +185,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2490[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2490[0m
+[33m[your-program] [0m[0m[1] 2918[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2918[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2492[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2492[0m
+[33m[your-program] [0m[0m[2] 2920[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2920[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -198,8 +198,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2494[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2494[0m
+[33m[your-program] [0m[0m[2] 2922[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2922[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -12,21 +12,37 @@ Debug = true
 
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
-[33m[tester::#AT7] [setup] [0m[94mmkfifo /tmp/pear-70[0m
-[33m[your-program] [0m[0m$ grep raspberry /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2719[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2719[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
+[33m[your-program] [0m[0m[1] 2731[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2731[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
-[33m[tester::#AT7] [setup] [0m[94mecho "raspberry" > "/tmp/pear-70"[0m
-[33m[your-program] [0m[0m$ raspberry[0m
-[33m[tester::#AT7] [0m[92m✓ Output of 'grep raspberry /tmp/pear-70' found in the next prompt line[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
+
+[33m[tester::#SI2] [0m[94mRunning tests for Stage #SI2 (si2)[0m
+[33m[tester::#SI2] [0m[94mRunning ./your_shell.sh[0m
+[33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
+[33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
+[33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
+[33m[your-program] [0m[0m[1] 2734[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2734[0m
+[33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
+[33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
+[33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #1\n" > "/tmp/apple-80"[0m
+[33m[your-program] [0m[0mHello from FIFO #1[0m
+[33m[tester::#SI2] [0m[92m✓ Output of 'cat /tmp/apple-80' found[0m
+[33m[tester::#SI2] [setup] [0m[94mecho -ne "Hello from FIFO #2\n" > "/tmp/blueberry-54"[0m
+[33m[your-program] [0m[0mHello from FIFO #2[0m
+[33m[tester::#SI2] [0m[92m✓ Output of 'cat /tmp/blueberry-54' found[0m
+[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
+[33m[your-program] [0m[0m$ [0m
+[33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2722[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2722[0m
+[33m[your-program] [0m[0m[1] 2741[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2741[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -37,23 +53,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2726[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2726[0m
+[33m[your-program] [0m[0m[1] 2744[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2744[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2728[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2728[0m
+[33m[your-program] [0m[0m[2] 2746[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2746[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2730[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2730[0m
+[33m[your-program] [0m[0m[3] 2748[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2748[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -65,53 +81,47 @@ Debug = true
 
 [33m[tester::#MA9] [0m[94mRunning tests for Stage #MA9 (ma9)[0m
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
-[33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/mango-20[0m
-[33m[your-program] [0m[0m$ grep banana /tmp/mango-20 &[0m
-[33m[your-program] [0m[0m[1] 2736[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2736[0m
+[33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
+[33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
+[33m[your-program] [0m[0m[1] 2751[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2751[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
-[33m[your-program] [0m[0m[1]+  Running                    grep banana /tmp/mango-20 &[0m
+[33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
 [33m[tester::#MA9] [0m[92m✓ 1 entry matches the running job[0m
-[33m[tester::#MA9] [setup] [0m[94mecho "banana" > "/tmp/mango-20"[0m
-[33m[your-program] [0m[0m$ banana[0m
-[33m[tester::#MA9] [0m[92m✓ Output of background command 'grep' found[0m
-[33m[your-program] [0m[0mjobs[0m
-[33m[your-program] [0m[0m[1]+  Done                       grep banana /tmp/mango-20[0m
+[33m[tester::#MA9] [setup] [0m[94mecho -ne "" > "/tmp/apple-26"[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-26[0m
 [33m[tester::#MA9] [0m[92m✓ 1 entry matches the finished job[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#MA9] [0m[92mTest passed.[0m
 
 [33m[tester::#RQ2] [0m[94mRunning tests for Stage #RQ2 (rq2)[0m
-[33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/orange-70[0m
-[33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/apple-5[0m
+[33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/pineapple-90[0m
+[33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2739[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2739[0m
+[33m[your-program] [0m[0m[1] 2754[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2754[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep mango /tmp/orange-70 &[0m
-[33m[your-program] [0m[0m[2] 2741[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2741[0m
+[33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
+[33m[your-program] [0m[0m[2] 2756[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2756[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep apple /tmp/apple-5 &[0m
-[33m[your-program] [0m[0m[3] 2743[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2743[0m
+[33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
+[33m[your-program] [0m[0m[3] 2758[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2758[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
-[33m[tester::#RQ2] [setup] [0m[94mecho "mango" > "/tmp/orange-70"[0m
-[33m[your-program] [0m[0m$ mango[0m
-[33m[tester::#RQ2] [0m[92m✓ Output of 'grep mango /tmp/orange-70' found[0m
-[33m[your-program] [0m[0mjobs[0m
+[33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
+[33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[2]-  Done                       grep mango /tmp/orange-70[0m
-[33m[your-program] [0m[0m[3]+  Running                    grep apple /tmp/apple-5 &[0m
+[33m[your-program] [0m[0m[2]-  Done                       cat /tmp/pineapple-90[0m
+[33m[your-program] [0m[0m[3]+  Running                    cat /tmp/grape-92 &[0m
 [33m[tester::#RQ2] [0m[92m✓ Received 3 entries in the output[0m
-[33m[tester::#RQ2] [setup] [0m[94mecho "apple" > "/tmp/apple-5"[0m
-[33m[your-program] [0m[0m$ apple[0m
-[33m[tester::#RQ2] [0m[92m✓ Output of 'grep apple /tmp/apple-5' found[0m
-[33m[your-program] [0m[0mjobs[0m
+[33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/grape-92"[0m
+[33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[3]+  Done                       grep apple /tmp/apple-5[0m
+[33m[your-program] [0m[0m[3]+  Done                       cat /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[92m✓ Received 2 entries in the output[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m
@@ -120,26 +130,24 @@ Debug = true
 [33m[tester::#RQ2] [0m[92mTest passed.[0m
 
 [33m[tester::#BV8] [0m[94mRunning tests for Stage #BV8 (bv8)[0m
-[33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/pear-92[0m
+[33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2749[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2749[0m
+[33m[your-program] [0m[0m[1] 2763[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2763[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep pineapple /tmp/pear-92 &[0m
-[33m[your-program] [0m[0m[2] 2751[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2751[0m
+[33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
+[33m[your-program] [0m[0m[2] 2766[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2766[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
-[33m[your-program] [0m[0m[2]+  Running                    grep pineapple /tmp/pear-92 &[0m
+[33m[your-program] [0m[0m[2]+  Running                    cat /tmp/mango-48 &[0m
 [33m[tester::#BV8] [0m[92m✓ Found 2 entries for the running jobs[0m
-[33m[tester::#BV8] [setup] [0m[94mecho "pineapple" > "/tmp/pear-92"[0m
-[33m[your-program] [0m[0m$ pineapple[0m
-[33m[tester::#BV8] [0m[92m✓ Output of 'grep pineapple /tmp/pear-92' found[0m
-[33m[your-program] [0m[0mecho raspberry[0m
-[33m[your-program] [0m[0mraspberry[0m
-[33m[your-program] [0m[0m[2]+  Done                       grep pineapple /tmp/pear-92[0m
+[33m[tester::#BV8] [setup] [0m[94mecho -ne "" > "/tmp/mango-48"[0m
+[33m[your-program] [0m[0m$ echo pear[0m
+[33m[your-program] [0m[0mpear[0m
+[33m[your-program] [0m[0m[2]+  Done                       cat /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[92m✓ Found command output followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 500 &[0m
@@ -148,52 +156,48 @@ Debug = true
 [33m[tester::#BV8] [0m[92mTest passed.[0m
 
 [33m[tester::#FY4] [0m[94mRunning tests for Stage #FY4 (fy4)[0m
-[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-92[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ grep mango /tmp/apple-92 &[0m
-[33m[your-program] [0m[0m[1] 2754[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2754[0m
+[33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
+[33m[your-program] [0m[0m[1] 2769[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2769[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
-[33m[tester::#FY4] [setup] [0m[94mecho "mango" > "/tmp/apple-92"[0m
-[33m[your-program] [0m[0m$ mango[0m
-[33m[tester::#FY4] [0m[92m✓ Output of 'grep mango /tmp/apple-92' found[0m
-[33m[your-program] [0m[0mecho apple[0m
-[33m[your-program] [0m[0mapple[0m
-[33m[your-program] [0m[0m[1]+  Done                       grep mango /tmp/apple-92[0m
+[33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
+[33m[your-program] [0m[0m$ echo blueberry[0m
+[33m[your-program] [0m[0mblueberry[0m
+[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
-[33m[your-program] [0m[0m$ echo grape[0m
-[33m[your-program] [0m[0mgrape[0m
+[33m[your-program] [0m[0m$ echo strawberry[0m
+[33m[your-program] [0m[0mstrawberry[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2756[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2756[0m
+[33m[your-program] [0m[0m[1] 2771[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2771[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
 [33m[tester::#FY4] [0m[92m✓ 1 entry matches the running job[0m
 [33m[tester::#FY4] [0m[94mTearing down shell[0m
-[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-9[0m
+[33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2759[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2759[0m
+[33m[your-program] [0m[0m[1] 2774[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2774[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
-[33m[your-program] [0m[0m$ grep orange /tmp/apple-9 &[0m
-[33m[your-program] [0m[0m[2] 2761[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2761[0m
+[33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
+[33m[your-program] [0m[0m[2] 2776[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2776[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
-[33m[tester::#FY4] [setup] [0m[94mecho "orange" > "/tmp/apple-9"[0m
-[33m[your-program] [0m[0m$ orange[0m
-[33m[tester::#FY4] [0m[92m✓ Output of 'grep orange /tmp/apple-9' found[0m
-[33m[your-program] [0m[0mecho apple[0m
+[33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
+[33m[your-program] [0m[0m$ echo apple[0m
 [33m[your-program] [0m[0mapple[0m
-[33m[your-program] [0m[0m[2]+  Done                       grep orange /tmp/apple-9[0m
+[33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2763[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2763[0m
+[33m[your-program] [0m[0m[2] 2778[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2778[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/zsh/your_shell.sh
+++ b/internal/test_helpers/zsh/your_shell.sh
@@ -8,4 +8,4 @@ rm -rf /etc/zshrc
 rm -rf ~/.zshrc
 rm -rf /etc/zlogin
 rm -rf ~/.zlogin 
-ZDOTDIR="$(dirname "$0")/zsh_config" zsh
+ZDOTDIR="$(dirname "$0")/zsh_config" exec zsh

--- a/internal/test_helpers/zsh/zsh_config/.zshrc
+++ b/internal/test_helpers/zsh/zsh_config/.zshrc
@@ -47,3 +47,6 @@ unsetopt AUTO_REMOVE_SLASH
 # bindkey "^I" _list-or-complete-newline
 # zstyle ':completion:*' menu no
 # zstyle ':completion:*' select 0
+
+# Disable automatically printing notifications when background jobs finish - Force Bash's behavior
+unsetopt NOTIFY

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -203,33 +203,38 @@ var testerDefinition = tester_definition.TesterDefinition{
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "jd6",
+			Slug:     "si2",
 			TestFunc: testBG3,
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "dk5",
+			Slug:     "jd6",
 			TestFunc: testBG4,
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "ma9",
+			Slug:     "dk5",
 			TestFunc: testBG5,
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "rq2",
+			Slug:     "ma9",
 			TestFunc: testBG6,
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "bv8",
+			Slug:     "rq2",
 			TestFunc: testBG7,
 			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:     "fy4",
+			Slug:     "bv8",
 			TestFunc: testBG8,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "fy4",
+			TestFunc: testBG9,
 			Timeout:  15 * time.Second,
 		},
 		// Pipelines

--- a/internal/utils_fs.go
+++ b/internal/utils_fs.go
@@ -185,7 +185,7 @@ func WriteToFile(stageHarness *test_case_harness.TestCaseHarness, filePath strin
 		return err
 	}
 	stageHarness.Logger.WithAdditionalSecondaryPrefix("setup", func() {
-		stageHarness.Logger.Infof("echo %q > %q", contents, filePath)
+		stageHarness.Logger.Infof("echo -ne %q > %q", contents, filePath)
 	})
 	return nil
 }

--- a/internal/utils_fs.go
+++ b/internal/utils_fs.go
@@ -185,7 +185,16 @@ func WriteToFile(stageHarness *test_case_harness.TestCaseHarness, filePath strin
 		return err
 	}
 	stageHarness.Logger.WithAdditionalSecondaryPrefix("setup", func() {
-		stageHarness.Logger.Infof("echo -ne %q > %q", contents, filePath)
+		// Log the 'no trailing newline' and 'enable backslash escapes' flags: Just like the logs in grep tester
+		echoFlag := "-ne"
+		logContents := contents
+
+		// If we're writing the newline character too, remove the -n flag and remove the suffix while logging
+		if strings.HasSuffix(contents, "\n") {
+			echoFlag = "-e"
+			logContents = strings.TrimSuffix(contents, "\n")
+		}
+		stageHarness.Logger.Infof("echo %s %q > %q", echoFlag, logContents, filePath)
 	})
 	return nil
 }


### PR DESCRIPTION
- Added Stage 3 for testing background command output
- Most of the diffs seen here are because of renaming 3->4, 4->5, ..., 8->9
- Added ZSH tests and removed them later because ZSH's jobs output printing order is different from that of Bash. ([Ref](https://github.com/codecrafters-io/shell-tester/actions/runs/22662320401/job/65685341047))
  - Couldn't find any settings to change in `.zshrc` to make this behave like Bash



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core tester assertion behavior around command reflection/prompt handling and reshuffles multiple background-jobs stages/fixtures; could cause subtle mismatches in expected output ordering/timing across shells.
> 
> **Overview**
> **Background-jobs test flow is reworked.** A new Stage#3 (`si2`) is introduced to verify that *background job stdout is printed to the terminal* while a foreground job is running, using FIFO-driven `cat` commands.
> 
> **Stages are renumbered and simplified.** Existing background-jobs stages shift down (old 3→4 … 8→9), with several tests switching from FIFO+`grep` output checks to `sleep`/FIFO+`cat` patterns for determinism; a new `testBG9` now owns the job-number reset coverage.
> 
> **Tester assertions are tightened/cleaned up.** `BackgroundCommandOutputOnlyTestCase` is replaced by a more general `OutputOnlyTestCase` (no prompt-line special-casing), and “skip current prompt reflection” options are removed from `JobsBuiltinResponseTestCase`, `CommandWithMultilineResponseTestCase`, and `CommandResponseWithReapedJobsTestCase`, making command reflections always expect `$ <cmd>`.
> 
> **Fixtures and helpers updated.** Background-jobs fixtures are regenerated to reflect the new commands/stage order, `WriteToFile` logging now emits `echo -e`/`echo -ne` to mirror behavior, and zsh harness/config is tweaked (`exec zsh`, `unsetopt NOTIFY`) to reduce background-job notification noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e78318575637e278bc9cab03c0157e719b788e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->