### PR TITLE
Update regex pattern to two or more spaces #wh6

### DIFF
--- a/internal/stage_a5.go
+++ b/internal/stage_a5.go
@@ -52,7 +52,7 @@ func testA5(stageHarness *test_case_harness.TestCaseHarness) error {
 		TabCount:                      2,
 		ExpectedCompletionOptionsLine: completions,
 		ExpectedCompletionOptionsLineFallbackPatterns: []*regexp.Regexp{
-			regexp.MustCompile("^" + strings.Join(escapedExecutableNames, `\s+`) + "$"),
+			regexp.MustCompile("^" + strings.Join(escapedExecutableNames, `\s{2,}`) + "$"),
 		},
 		SuccessMessage:      fmt.Sprintf("Received completion for %q", command),
 		CheckForBell:        true,


### PR DESCRIPTION
In tandem: https://github.com/codecrafters-io/build-your-own-shell/pull/305

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens a completion-output fallback regex in a stage test, which can change pass/fail behavior for shells that separate completion options with a single space or other whitespace.
> 
> **Overview**
> Updates the stage A5 multiple-completions test to accept fallback matches only when completion options are separated by *two or more* whitespace characters (`\s{2,}`) instead of *one or more* (`\s+`). This makes the completion-output validation align with the expected double-space formatting and reduces tolerance for alternative spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7635a36ef19f4be253053e1be5419ef8b5c1d1eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->