### PR TITLE
Hint for Jobs Test Case

### DIFF
--- a/internal/assertions/empty_line_assertion.go
+++ b/internal/assertions/empty_line_assertion.go
@@ -30,7 +30,7 @@ func (a EmptyLineAssertion) Run(screenState screen_state.ScreenState, startRowIn
 	}
 
 	// Build error message
-	detailedErrorMessage := utils.BuildColoredErrorMessage("(empty line)", row.String(), "")
+	detailedErrorMessage := utils.BuildColoredErrorMessage("(empty line)", row.String(), "", "")
 	message := "Line is not empty.\n" + detailedErrorMessage
 
 	return 0, &AssertionError{

--- a/internal/assertions/single_line_assertion.go
+++ b/internal/assertions/single_line_assertion.go
@@ -21,6 +21,9 @@ type SingleLineAssertion struct {
 	// should stay on the same line after the assertion is run
 	// Most probably because the next assertion will run on the same line
 	StayOnSameLine bool
+
+	// HintGenerator will generate a hint for the assertion error given the foundLine
+	HintGenerator func(foundLine string) string
 }
 
 func (a SingleLineAssertion) Inspect() string {
@@ -38,27 +41,29 @@ func (a SingleLineAssertion) Run(screenState screen_state.ScreenState, startRowI
 	}
 
 	row := screenState.GetRow(startRowIndex)
+	rowString := row.String()
 
 	for _, pattern := range a.FallbackPatterns {
-		if pattern.Match([]byte(row.String())) {
+		if pattern.Match([]byte(rowString)) {
 			return processedRowCount, nil
 		}
 	}
 
-	if row.String() != a.ExpectedOutput {
+	if rowString != a.ExpectedOutput {
 		rowDescription := ""
 
 		if startRowIndex > screenState.GetLastLoggableRowIndex() {
 			rowDescription = "no line received"
 		} else if row.IsEmpty() {
 			rowDescription = "empty line"
-		} else if strings.HasSuffix(a.ExpectedOutput, " ") && !strings.HasSuffix(row.String(), " ") {
+		} else if strings.HasSuffix(a.ExpectedOutput, " ") && !strings.HasSuffix(rowString, " ") {
 			rowDescription = "no trailing space"
-		} else if !strings.HasSuffix(a.ExpectedOutput, " ") && strings.HasSuffix(row.String(), " ") {
+		} else if !strings.HasSuffix(a.ExpectedOutput, " ") && strings.HasSuffix(rowString, " ") {
 			rowDescription = "trailing space"
 		}
 
-		detailedErrorMessage := utils.BuildColoredErrorMessage(a.ExpectedOutput, row.String(), rowDescription)
+		extraHint := a.generateExtraHint(rowString)
+		detailedErrorMessage := utils.BuildColoredErrorMessage(a.ExpectedOutput, rowString, rowDescription, extraHint)
 
 		// If the line won't be logged, we say "didn't find line ..." instead of "line does not match expected ..."
 		if startRowIndex > screenState.GetLastLoggableRowIndex() {
@@ -75,4 +80,11 @@ func (a SingleLineAssertion) Run(screenState screen_state.ScreenState, startRowI
 	} else {
 		return processedRowCount, nil
 	}
+}
+
+func (a SingleLineAssertion) generateExtraHint(foundLine string) string {
+	if a.HintGenerator != nil {
+		return a.HintGenerator(foundLine)
+	}
+	return ""
 }

--- a/internal/assertions/single_line_assertion.go
+++ b/internal/assertions/single_line_assertion.go
@@ -22,8 +22,8 @@ type SingleLineAssertion struct {
 	// Most probably because the next assertion will run on the same line
 	StayOnSameLine bool
 
-	// HintGenerator will generate a hint for the assertion error given the foundLine
-	HintGenerator func(foundLine string) string
+	// ErrorHintGenerator will generate a hint for the assertion error given the foundLine
+	ErrorHintGenerator func(foundLine string) string
 }
 
 func (a SingleLineAssertion) Inspect() string {
@@ -83,8 +83,8 @@ func (a SingleLineAssertion) Run(screenState screen_state.ScreenState, startRowI
 }
 
 func (a SingleLineAssertion) generateExtraHint(foundLine string) string {
-	if a.HintGenerator != nil {
-		return a.HintGenerator(foundLine)
+	if a.ErrorHintGenerator != nil {
+		return a.ErrorHintGenerator(foundLine)
 	}
 	return ""
 }

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -82,13 +82,14 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	// Sleep to ensure that the next the reaped job entry is printed always (For fixtures)
+	time.Sleep(time.Millisecond)
+
 	// Write to the fifo 2, and assert the output
 	fifo2Contents := "Hello from FIFO #2\n"
 	if err := WriteToFile(stageHarness, fifoPath2, fifo2Contents); err != nil {
 		return err
 	}
-
-	time.Sleep(time.Millisecond)
 
 	// Assert foreground cat command output
 	fgCommandOutputTestCase := test_cases.OutputOnlyTestCase{

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -12,6 +11,7 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
+	"github.com/codecrafters-io/tester-utils/testing"
 )
 
 func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -82,9 +82,6 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Sleep to ensure that the next the reaped job entry is printed always (For fixtures)
-	time.Sleep(10 * time.Millisecond)
-
 	// Write to the fifo 2, and assert the output
 	fifo2Contents := "Hello from FIFO #2\n"
 	if err := WriteToFile(stageHarness, fifoPath2, fifo2Contents); err != nil {
@@ -99,6 +96,13 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	if err := fgCommandOutputTestCase.Run(asserter, shell, logger); err != nil {
 		return err
+	}
+
+	// Fixtures are inconsistent for this stage because we cannot guarantee
+	// if the first cat job was Done or not by then. The shell may or may not print
+	// the 'Done' entry for that job
+	if testing.IsRecordingOrEvaluatingFixtures() {
+		return nil
 	}
 
 	return logAndQuit(asserter, nil)

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -99,8 +99,10 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Fixtures are inconsistent for this stage because we cannot guarantee
-	// if the first cat job was Done or not by then. The shell may or may not print
-	// the 'Done' entry for that job
+	// if the first 'cat' job was reaped by the time the output for the foreground
+	// 'cat' job finishes. The shell may or may not print
+	// the 'Done' entry for that job depending on whether the former 'cat' was reaped by the time the
+	// second output is shown
 	if testing.IsRecordingOrEvaluatingFixtures() {
 		return nil
 	}

--- a/internal/stage_bg3.go
+++ b/internal/stage_bg3.go
@@ -83,7 +83,7 @@ func testBG3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Sleep to ensure that the next the reaped job entry is printed always (For fixtures)
-	time.Sleep(time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Write to the fifo 2, and assert the output
 	fifo2Contents := "Hello from FIFO #2\n"

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -153,6 +153,13 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_incorrect_pid",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"background_jobs_extra_ampersand": {
+			StageSlugs:          []string{"ma9"},
+			CodePath:            "./test_helpers/scenarios/background_jobs_extra_ampersand",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_extra_ampersand",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"pipelines_pass_bash": {
 			StageSlugs:          []string{"br6", "ny9", "xk3"},
 			CodePath:            "./test_helpers/bash",

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -3,6 +3,7 @@ package test_cases
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -62,6 +63,12 @@ func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Rege
 	return expectedOutput, regexp.MustCompile(regexString)
 }
 
+func (e BackgroundJobStatusEntry) hasTrailingAmpersand() bool {
+	_, regex := e.ExpectedOutputAndRegex()
+	regexString := regex.String()
+	return strings.HasSuffix(regexString, "( )?$")
+}
+
 type JobsBuiltinResponseTestCase struct {
 	ExpectedOutputEntries []BackgroundJobStatusEntry
 	SuccessMessage        string
@@ -97,6 +104,13 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 		asserter.AddAssertion(assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
 			FallbackPatterns: []*regexp.Regexp{regexPattern},
+			HintGenerator: func(receivedLine string) string {
+				foundLineHasTrailingAmpersand := strings.HasSuffix(receivedLine, "&")
+				if foundLineHasTrailingAmpersand && !expectedOutputEntry.hasTrailingAmpersand() {
+					return "Entry should not have trailing ampersand"
+				}
+				return ""
+			},
 		})
 
 		assertWithPrompt := false

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -3,7 +3,6 @@ package test_cases
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -102,12 +101,28 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 		asserter.AddAssertion(assertions.SingleLineAssertion{
 			ExpectedOutput:   expectedOutput,
 			FallbackPatterns: []*regexp.Regexp{regexPattern},
-			HintGenerator: func(receivedLine string) string {
-				foundLineHasTrailingAmpersand := strings.HasSuffix(receivedLine, "&")
-				if foundLineHasTrailingAmpersand && !expectedOutputEntry.hasTrailingAmpersand() {
-					return "Entry should not have trailing ampersand"
+			ErrorHintGenerator: func(receivedLine string) string {
+				// If expected entry has a trailing ampersand
+				// don't generate any hint
+				if expectedOutputEntry.hasTrailingAmpersand() {
+					return ""
 				}
-				return ""
+
+				// If the output still complies with the expected regex, but has an extra ampersand
+				// raise error
+				regexForUnexpectedTrailingAmpersand := regexp.MustCompile(fmt.Sprintf(
+					`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s &$`,
+					expectedOutputEntry.JobNumber,
+					regexp.QuoteMeta(convertJobMarkerToString(expectedOutputEntry.Marker)),
+					regexp.QuoteMeta(expectedOutputEntry.Status),
+					regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
+				))
+
+				if !regexForUnexpectedTrailingAmpersand.Match([]byte(receivedLine)) {
+					return ""
+				}
+
+				return "Finished job entry should not have a trailing ampersand"
 			},
 		})
 

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -44,7 +44,7 @@ func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Rege
 	// For 'Running' jobs, bash displays the trailing & sign
 	// Users shall comply with bash for consistency (Ensured this by appending this to expected output)
 	// But this should be optional since ZSH doesn't use this
-	if e.Status == "Running" {
+	if e.hasTrailingAmpersand() {
 		regexString += "( &)?$"
 	} else {
 		regexString += "$"
@@ -56,7 +56,7 @@ func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Rege
 	)
 
 	// For 'Running' jobs, the trailing sign is expected
-	if e.Status == "Running" {
+	if e.hasTrailingAmpersand() {
 		expectedOutput += " &"
 	}
 
@@ -64,9 +64,7 @@ func (e BackgroundJobStatusEntry) ExpectedOutputAndRegex() (string, *regexp.Rege
 }
 
 func (e BackgroundJobStatusEntry) hasTrailingAmpersand() bool {
-	_, regex := e.ExpectedOutputAndRegex()
-	regexString := regex.String()
-	return strings.HasSuffix(regexString, "( )?$")
+	return e.Status == "Running"
 }
 
 type JobsBuiltinResponseTestCase struct {

--- a/internal/test_cases/jobs_builtin_response_test_case.go
+++ b/internal/test_cases/jobs_builtin_response_test_case.go
@@ -3,6 +3,7 @@ package test_cases
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -108,21 +109,15 @@ func (t JobsBuiltinResponseTestCase) Run(asserter *logged_shell_asserter.LoggedS
 					return ""
 				}
 
-				// If the output still complies with the expected regex, but has an extra ampersand
-				// raise error
-				regexForUnexpectedTrailingAmpersand := regexp.MustCompile(fmt.Sprintf(
-					`^\[%d\]\s*%s\s+(?i)%s\s+(?-i)%s &$`,
-					expectedOutputEntry.JobNumber,
-					regexp.QuoteMeta(convertJobMarkerToString(expectedOutputEntry.Marker)),
-					regexp.QuoteMeta(expectedOutputEntry.Status),
-					regexp.QuoteMeta(expectedOutputEntry.LaunchCommand),
-				))
-
-				if !regexForUnexpectedTrailingAmpersand.Match([]byte(receivedLine)) {
-					return ""
+				// If the output has the suffix ' &' and the part without the suffix
+				// matches the regex,
+				if outputWithoutTrailingAmpersand, found := strings.CutSuffix(receivedLine, " &"); found {
+					if regexPattern.Match([]byte(outputWithoutTrailingAmpersand)) {
+						return "Finished job entry cannot have a trailing ampersand"
+					}
 				}
 
-				return "Finished job entry should not have a trailing ampersand"
+				return ""
 			},
 		})
 

--- a/internal/test_helpers/fixtures/background_jobs_extra_ampersand
+++ b/internal/test_helpers/fixtures/background_jobs_extra_ampersand
@@ -1,21 +1,21 @@
 Debug = true
 
-[tester::#MA9] Running tests for Stage #MA9 (ma9)
-[tester::#MA9] Running ./your_program.sh
-[tester::#MA9] [setup] mkfifo /tmp/pear-70
-[your-program] $ cat /tmp/pear-70 &
-[your-program] [1] 43646
-[tester::#MA9] ✓ Found process with PID 43646
-[tester::#MA9] ✓ Output includes job number with PID
-[your-program] $ jobs
-[your-program] [1]+  Running                 cat /tmp/pear-70 &
-[tester::#MA9] ✓ 1 entry matches the running job
-[tester::#MA9] [setup] echo -ne "" > "/tmp/pear-70"
-[your-program] $ jobs
-[your-program] [1]+  Done                 cat /tmp/pear-70 &
-[tester::#MA9] ^ Line does not match expected value.
-[tester::#MA9] Expected: "[1]+  Done                 cat /tmp/pear-70"
-[tester::#MA9] Received: "[1]+  Done                 cat /tmp/pear-70 &"
-[tester::#MA9] Expected job entry to not have trailing ampersand
-[your-program] $ 
-[tester::#MA9] Test failed
+[33m[tester::#MA9] [0m[94mRunning tests for Stage #MA9 (ma9)[0m
+[33m[tester::#MA9] [0m[94mRunning ./your_program.sh[0m
+[33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
+[33m[your-program] [0m[0m$ cat /tmp/pear-70 &[0m
+[33m[your-program] [0m[0m[1] 2581[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2581[0m
+[33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]+  Running                 cat /tmp/pear-70 &[0m
+[33m[tester::#MA9] [0m[92m✓ 1 entry matches the running job[0m
+[33m[tester::#MA9] [setup] [0m[94mecho -ne "" > "/tmp/pear-70"[0m
+[33m[your-program] [0m[0m$ jobs[0m
+[33m[your-program] [0m[0m[1]+  Done                 cat /tmp/pear-70 &[0m
+[33m[tester::#MA9] [0m[91m^ Line does not match expected value.[0m
+[33m[tester::#MA9] [0m[91m[32mExpected:[0m "[1]+  Done                 cat /tmp/pear-70"[0m
+[33m[tester::#MA9] [0m[91m[31mReceived:[0m "[1]+  Done                 cat /tmp/pear-70 &"[0m
+[33m[tester::#MA9] [0m[91mFinished job entry should not have a trailing ampersand[0m
+[33m[your-program] [0m[0m$ [0m
+[33m[tester::#MA9] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_extra_ampersand
+++ b/internal/test_helpers/fixtures/background_jobs_extra_ampersand
@@ -1,0 +1,21 @@
+Debug = true
+
+[tester::#MA9] Running tests for Stage #MA9 (ma9)
+[tester::#MA9] Running ./your_program.sh
+[tester::#MA9] [setup] mkfifo /tmp/pear-70
+[your-program] $ cat /tmp/pear-70 &
+[your-program] [1] 43646
+[tester::#MA9] ✓ Found process with PID 43646
+[tester::#MA9] ✓ Output includes job number with PID
+[your-program] $ jobs
+[your-program] [1]+  Running                 cat /tmp/pear-70 &
+[tester::#MA9] ✓ 1 entry matches the running job
+[tester::#MA9] [setup] echo -ne "" > "/tmp/pear-70"
+[your-program] $ jobs
+[your-program] [1]+  Done                 cat /tmp/pear-70 &
+[tester::#MA9] ^ Line does not match expected value.
+[tester::#MA9] Expected: "[1]+  Done                 cat /tmp/pear-70"
+[tester::#MA9] Received: "[1]+  Done                 cat /tmp/pear-70 &"
+[tester::#MA9] Expected job entry to not have trailing ampersand
+[your-program] $ 
+[tester::#MA9] Test failed

--- a/internal/test_helpers/fixtures/background_jobs_extra_ampersand
+++ b/internal/test_helpers/fixtures/background_jobs_extra_ampersand
@@ -4,8 +4,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_program.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ cat /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2581[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2581[0m
+[33m[your-program] [0m[0m[1] 2991[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2991[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                 cat /tmp/pear-70 &[0m
@@ -16,6 +16,6 @@ Debug = true
 [33m[tester::#MA9] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#MA9] [0m[91m[32mExpected:[0m "[1]+  Done                 cat /tmp/pear-70"[0m
 [33m[tester::#MA9] [0m[91m[31mReceived:[0m "[1]+  Done                 cat /tmp/pear-70 &"[0m
-[33m[tester::#MA9] [0m[91mFinished job entry should not have a trailing ampersand[0m
+[33m[tester::#MA9] [0m[91mFinished job entry cannot have a trailing ampersand[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#MA9] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2317[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2317[0m
+[33m[your-program] [0m[0m[1] 2651[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2651[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2320[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2320[0m
+[33m[your-program] [0m[0m[1] 2654[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2654[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -34,14 +34,13 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
-[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2325[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2325[0m
+[33m[your-program] [0m[0m[1] 2658[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2658[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -52,23 +51,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2328[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2328[0m
+[33m[your-program] [0m[0m[1] 2666[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2666[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2331[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2331[0m
+[33m[your-program] [0m[0m[2] 2668[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2668[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2333[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2333[0m
+[33m[your-program] [0m[0m[3] 2670[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2670[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -82,8 +81,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2336[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2336[0m
+[33m[your-program] [0m[0m[1] 2673[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2673[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -102,16 +101,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2340[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2340[0m
+[33m[your-program] [0m[0m[1] 2677[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2677[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2342[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2342[0m
+[33m[your-program] [0m[0m[2] 2679[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2679[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2344[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2344[0m
+[33m[your-program] [0m[0m[3] 2681[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2681[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -134,12 +133,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2348[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2348[0m
+[33m[your-program] [0m[0m[1] 2684[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2684[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2350[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2350[0m
+[33m[your-program] [0m[0m[2] 2686[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2686[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -160,8 +159,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2354[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2354[0m
+[33m[your-program] [0m[0m[1] 2691[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2691[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -174,8 +173,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2357[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2357[0m
+[33m[your-program] [0m[0m[1] 2693[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2693[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -184,12 +183,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2360[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2360[0m
+[33m[your-program] [0m[0m[1] 2696[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2696[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2362[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2362[0m
+[33m[your-program] [0m[0m[2] 2700[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2700[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -197,8 +196,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2364[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2364[0m
+[33m[your-program] [0m[0m[2] 2702[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2702[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2190[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2190[0m
+[33m[your-program] [0m[0m[1] 2317[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2317[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2193[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2193[0m
+[33m[your-program] [0m[0m[1] 2320[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2320[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -34,13 +34,14 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
+[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2197[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2197[0m
+[33m[your-program] [0m[0m[1] 2325[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2325[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -51,23 +52,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2200[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2200[0m
+[33m[your-program] [0m[0m[1] 2328[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2328[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2202[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2202[0m
+[33m[your-program] [0m[0m[2] 2331[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2331[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2205[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2205[0m
+[33m[your-program] [0m[0m[3] 2333[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2333[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -81,8 +82,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2208[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2208[0m
+[33m[your-program] [0m[0m[1] 2336[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2336[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -101,16 +102,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2213[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2213[0m
+[33m[your-program] [0m[0m[1] 2340[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2340[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2215[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2215[0m
+[33m[your-program] [0m[0m[2] 2342[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2342[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2217[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2217[0m
+[33m[your-program] [0m[0m[3] 2344[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2344[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -133,12 +134,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2221[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2221[0m
+[33m[your-program] [0m[0m[1] 2348[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2348[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2223[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2223[0m
+[33m[your-program] [0m[0m[2] 2350[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2350[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -159,8 +160,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2228[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2228[0m
+[33m[your-program] [0m[0m[1] 2354[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2354[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -173,8 +174,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2230[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2230[0m
+[33m[your-program] [0m[0m[1] 2357[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2357[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -183,12 +184,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2233[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2233[0m
+[33m[your-program] [0m[0m[1] 2360[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2360[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2235[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2235[0m
+[33m[your-program] [0m[0m[2] 2362[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2362[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -196,8 +197,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2237[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2237[0m
+[33m[your-program] [0m[0m[2] 2364[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2364[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2651[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2651[0m
+[33m[your-program] [0m[0m[1] 2159[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2159[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2654[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2654[0m
+[33m[your-program] [0m[0m[1] 2162[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2162[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -34,13 +34,15 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
+[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2658[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2658[0m
+[33m[your-program] [0m[0m[1] 2166[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2166[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -51,23 +53,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2666[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2666[0m
+[33m[your-program] [0m[0m[1] 2169[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2169[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2668[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2668[0m
+[33m[your-program] [0m[0m[2] 2172[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2172[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2670[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2670[0m
+[33m[your-program] [0m[0m[3] 2174[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2174[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -81,8 +83,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2673[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2673[0m
+[33m[your-program] [0m[0m[1] 2178[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2178[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -101,16 +103,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2677[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2677[0m
+[33m[your-program] [0m[0m[1] 2181[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2181[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2679[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2679[0m
+[33m[your-program] [0m[0m[2] 2183[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2183[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2681[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2681[0m
+[33m[your-program] [0m[0m[3] 2186[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2186[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -133,12 +135,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2684[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2684[0m
+[33m[your-program] [0m[0m[1] 2190[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2190[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2686[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2686[0m
+[33m[your-program] [0m[0m[2] 2192[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2192[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -159,8 +161,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2691[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2691[0m
+[33m[your-program] [0m[0m[1] 2195[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2195[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -173,8 +175,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2693[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2693[0m
+[33m[your-program] [0m[0m[1] 2198[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2198[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -183,12 +185,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2696[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2696[0m
+[33m[your-program] [0m[0m[1] 2201[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2201[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2700[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2700[0m
+[33m[your-program] [0m[0m[2] 2203[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2203[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -196,8 +198,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2702[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2702[0m
+[33m[your-program] [0m[0m[2] 2206[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2206[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,8 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2159[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2159[0m
+[33m[your-program] [0m[0m[1] 2662[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2662[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2162[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2162[0m
+[33m[your-program] [0m[0m[1] 2665[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2665[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -34,15 +34,13 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #2" > "/tmp/blueberry-54"[0m
 [33m[your-program] [0m[0mHello from FIFO #2[0m
 [33m[tester::#SI2] [0m[92m✓ Received output from foreground job 'cat /tmp/blueberry-54'[0m
-[33m[your-program] [0m[0m[1]+  Done                       cat /tmp/apple-80[0m
-[33m[your-program] [0m[0m$ [0m
 [33m[tester::#SI2] [0m[92mTest passed.[0m
 
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2166[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2166[0m
+[33m[your-program] [0m[0m[1] 2669[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2669[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -53,23 +51,23 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2169[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2169[0m
+[33m[your-program] [0m[0m[1] 2672[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2672[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2172[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2172[0m
+[33m[your-program] [0m[0m[2] 2678[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2678[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2174[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2174[0m
+[33m[your-program] [0m[0m[3] 2680[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2680[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -83,8 +81,8 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2178[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2178[0m
+[33m[your-program] [0m[0m[1] 2683[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2683[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -103,16 +101,16 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2181[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2181[0m
+[33m[your-program] [0m[0m[1] 2686[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2686[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2183[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2183[0m
+[33m[your-program] [0m[0m[2] 2688[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2688[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2186[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2186[0m
+[33m[your-program] [0m[0m[3] 2690[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2690[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -135,12 +133,12 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2190[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2190[0m
+[33m[your-program] [0m[0m[1] 2696[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2696[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2192[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2192[0m
+[33m[your-program] [0m[0m[2] 2698[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2698[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -161,8 +159,8 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2195[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2195[0m
+[33m[your-program] [0m[0m[1] 2701[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2701[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -175,8 +173,8 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2198[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2198[0m
+[33m[your-program] [0m[0m[1] 2703[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2703[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -185,12 +183,12 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2201[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2201[0m
+[33m[your-program] [0m[0m[1] 2707[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2707[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2203[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2203[0m
+[33m[your-program] [0m[0m[2] 2709[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2709[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -198,8 +196,8 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2206[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2206[0m
+[33m[your-program] [0m[0m[2] 2711[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2711[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/scenarios/background_jobs_extra_ampersand/codecrafters.yml
+++ b/internal/test_helpers/scenarios/background_jobs_extra_ampersand/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/background_jobs_extra_ampersand/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_extra_ampersand/main.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Buggy shell for ma9 fixtures: `jobs` appends ` &` even for Done entries (bash only does that for Running)."""
+
+import os
+import sys
+import subprocess
+import shlex
+
+PROMPT = "$ "
+BUILTINS = {"echo", "exit", "type", "jobs"}
+
+# {"job_id": int, "launch_cmd": str, "process": Popen}
+BACKGROUND_JOBS: list[dict] = []
+
+
+def find_in_path(name: str) -> str | None:
+    path = os.environ.get("PATH", "")
+    for part in path.split(os.pathsep):
+        if not part:
+            continue
+        full = os.path.join(part, name)
+        if os.path.isfile(full) and os.access(full, os.X_OK):
+            return full
+    return None
+
+
+def job_status(proc: subprocess.Popen) -> str:
+    return "Done" if proc.poll() is not None else "Running"
+
+
+def format_jobs_line(job_id: int, marker: str, status: str, launch_cmd: str) -> str:
+    line = f"[{job_id}]{marker}  {status}                 {launch_cmd}"
+    # Intentional bug: always print trailing ` &` like Running, even for Done.
+    line += " &"
+    return line
+
+
+def run_builtin(args: list[str], last_exit_code: int) -> tuple[str | None, int | None]:
+    if not args:
+        return None, None
+    cmd = args[0].lower()
+    if cmd == "exit":
+        code = int(args[1]) if len(args) > 1 else last_exit_code
+        if code < 0:
+            code = 0
+        return None, code
+    if cmd == "echo":
+        out = " ".join(args[1:]) if len(args) > 1 else ""
+        return out, None
+    if cmd == "type":
+        if len(args) < 2:
+            return None, None
+        name = args[1]
+        if name in BUILTINS:
+            return f"{name} is a shell builtin", None
+        path = find_in_path(name)
+        if path:
+            return f"{name} is {path}", None
+        return f"{name}: not found", None
+    if cmd == "jobs":
+        lines: list[str] = []
+        n = len(BACKGROUND_JOBS)
+        for i, job in enumerate(BACKGROUND_JOBS):
+            jid = job["job_id"]
+            launch_cmd = job["launch_cmd"]
+            proc = job["process"]
+            status = job_status(proc)
+            if i == n - 1:
+                marker = "+"
+            elif n >= 2 and i == n - 2:
+                marker = "-"
+            else:
+                marker = " "
+            lines.append(format_jobs_line(jid, marker, status, launch_cmd))
+        # Reap terminated jobs after listing (bash-style for this stage).
+        BACKGROUND_JOBS[:] = [j for j in BACKGROUND_JOBS if j["process"].poll() is None]
+        return "\n".join(lines) if lines else "", None
+    return None, None
+
+
+def run_external(args: list[str], background: bool = False) -> tuple[int | None, subprocess.Popen | None]:
+    name = args[0]
+    path = find_in_path(name)
+    if path is None:
+        print(f"{name}: command not found", file=sys.stderr)
+        return (127, None)
+    try:
+        if background:
+            proc = subprocess.Popen([path] + args[1:], env=os.environ)
+            return (None, proc)
+        proc = subprocess.run(
+            [path] + args[1:],
+            env=os.environ,
+            capture_output=False,
+            timeout=30,
+        )
+        return (proc.returncode, None)
+    except (OSError, subprocess.TimeoutExpired):
+        return (127, None)
+
+
+def main() -> None:
+    last_exit_code = 0
+    while True:
+        sys.stdout.write(PROMPT)
+        sys.stdout.flush()
+        try:
+            line = sys.stdin.readline()
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not line:
+            break
+        line = line.rstrip("\n\r")
+        background = line.rstrip().endswith("&")
+        if background:
+            line = line.rstrip()[:-1].rstrip()
+        parts = shlex.split(line)
+        if not parts:
+            continue
+        cmd = parts[0]
+        args = parts[1:]
+
+        if cmd in BUILTINS:
+            out, exit_code = run_builtin([cmd] + args, last_exit_code)
+            if exit_code is not None:
+                sys.exit(exit_code)
+            if out is not None:
+                print(out)
+                sys.stdout.flush()
+        else:
+            exit_code, bg_proc = run_external([cmd] + args, background=background)
+            if exit_code is not None:
+                last_exit_code = exit_code
+            else:
+                job_id = len(BACKGROUND_JOBS) + 1
+                launch_cmd = " ".join([cmd] + args)
+                BACKGROUND_JOBS.append(
+                    {"job_id": job_id, "launch_cmd": launch_cmd, "process": bg_proc}
+                )
+                print(f"[{job_id}] {bg_proc.pid}")
+                sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/background_jobs_extra_ampersand/your_program.sh
+++ b/internal/test_helpers/scenarios/background_jobs_extra_ampersand/your_program.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# This buggy implementation will always print a trailing ampersand for finished jobs
+exec python3 $(dirname "$0")/main.py "$@"

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -15,7 +15,7 @@ func ColorizeString(colorToUse color.Attribute, msg string) string {
 	return c.Sprint(msg)
 }
 
-func BuildColoredErrorMessage(expectedOutput string, receivedOutput string, receivedOutputDescription string) string {
+func BuildColoredErrorMessage(expectedOutput string, receivedOutput string, receivedOutputDescription string, extraHint string) string {
 	errorMsg := ColorizeString(color.FgGreen, "Expected:")
 	errorMsg += " \"" + expectedOutput + "\""
 	errorMsg += "\n"
@@ -24,6 +24,10 @@ func BuildColoredErrorMessage(expectedOutput string, receivedOutput string, rece
 
 	if receivedOutputDescription != "" {
 		errorMsg += " " + ColorizeString(color.FgRed, fmt.Sprintf("(%s)", receivedOutputDescription))
+	}
+
+	if extraHint != "" {
+		errorMsg += "\n" + extraHint
 	}
 
 	return errorMsg


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared assertion/error-message plumbing used across tests, so regressions could affect many failure outputs and fixture generation behavior. Functional changes are limited to diagnostics and test harness behavior, not user-facing shell execution.
> 
> **Overview**
> Adds support for appending an *extra hint line* to colored assertion error messages by extending `utils.BuildColoredErrorMessage` and wiring it through `SingleLineAssertion`/`EmptyLineAssertion`.
> 
> Updates the `jobs` builtin test case to generate a specific hint when a *finished* job line incorrectly includes a trailing ` &`, and adds a new failing scenario/fixture (`background_jobs_extra_ampersand`) to exercise this.
> 
> Adjusts `stage_bg3` to skip fixture recording/evaluation for a known timing-dependent output ordering case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f9c6670b0a7768b182eafccd96ec7fb1936c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->