### PR TITLE
Programmable Completion (Error Scenarios)

### DIFF
--- a/internal/stage_pa10.go
+++ b/internal/stage_pa10.go
@@ -1,5 +1,91 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"strconv"
 
-func testPA10(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testPA10(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	completerDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	commandName := "git"
+	completerPath := path.Join(completerDir, "singleCompleter")
+
+	completionSubcommand := random.RandomElementFromArray(
+		[]string{"clone", "add", "commit", "push"},
+	)
+
+	compLine := commandName + " "
+	compPoint := strconv.Itoa(len(compLine))
+
+	// We need not use a valid completer here, but a valid completer makes it
+	// obvious in the error messages
+	// that the completion script was run when it shouldn't have
+	if err := (&custom_executable.CompleterExecutableSpecification{
+		Path:        completerPath,
+		SecretValue: getRandomString(),
+		CompleterConfiguration: completer_configuration.CompleterConfiguration{
+			OutputLines: []string{completionSubcommand},
+			ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+				Argv1: commandName,
+				Argv2: "",
+				Argv3: commandName,
+			},
+			ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+				CompLine:  compLine,
+				CompPoint: compPoint,
+			},
+		},
+	}).Create(); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete  -C  '%s'  %s", completerPath, commandName)
+
+	if err := (test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}).Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	unregisterCmd := fmt.Sprintf("complete -r %s", commandName)
+
+	if err := (test_cases.CommandWithNoResponseTestCase{
+		Command:        unregisterCmd,
+		SuccessMessage: "✓ No output from complete -r",
+	}).Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	if err := (test_cases.AutocompleteTestCase{
+		RawInput:            commandName + " ",
+		ExpectedCompletion:  commandName + " ",
+		CheckForBell:        true,
+		SkipPromptAssertion: true,
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa8.go
+++ b/internal/stage_pa8.go
@@ -1,5 +1,113 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
-func testPA8(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+// gitMultiSubcommandChoice drives top-level `git <subcommand>` completion only (no nested words).
+// Completion strings are chosen so bash does not extend a longest-common-prefix past what the
+// user already typed: either they share no common prefix (empty partial), or their LCP equals partial.
+type gitMultiSubcommandChoice struct {
+	partial     string
+	completions []string
+}
+
+func testPA8(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	randomDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	command := "git"
+
+	// The partial script should not accidentally trigger LCP for this stage
+	// So we choose completions with no common remaining prefix
+	choices := []gitMultiSubcommandChoice{
+		{partial: "che", completions: []string{"checkout", "cherry-pick"}},
+		{partial: "re", completions: []string{"reset", "remote", "rebase"}},
+		{partial: "pu", completions: []string{"push", "pull"}},
+		{partial: "sta", completions: []string{"stash", "status"}},
+	}
+
+	choice := choices[random.RandomInt(0, len(choices))]
+
+	sortedCompletions := append([]string(nil), choice.completions...)
+	sort.Strings(sortedCompletions)
+
+	compLineEnvVar := fmt.Sprintf("%s %s", command, choice.partial)
+	completionsLine := strings.Join(sortedCompletions, "  ")
+
+	completerPath := path.Join(randomDir, "multiCandidateEnvCompleter")
+
+	if err := (&custom_executable.CompleterExecutableSpecification{
+		Path:        completerPath,
+		SecretValue: getRandomString(),
+		CompleterConfiguration: completer_configuration.CompleterConfiguration{
+			OutputLines: sortedCompletions,
+			ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+				Argv1: command,
+				Argv2: choice.partial,
+				Argv3: command,
+			},
+			ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+				CompLine:  compLineEnvVar,
+				CompPoint: strconv.Itoa(len(compLineEnvVar)),
+			},
+		},
+	}).Create(); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete -C %s %s", completerPath, command)
+	registerTestCase := test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}
+	if err := registerTestCase.Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	escapedCompletionChoices := make([]string, len(sortedCompletions))
+	for i, name := range sortedCompletions {
+		escapedCompletionChoices[i] = regexp.QuoteMeta(name)
+	}
+
+	multiCase := test_cases.MultipleCompletionsTestCase{
+		RawInput:                      compLineEnvVar,
+		TabCount:                      2,
+		CheckForBell:                  true,
+		ExpectedCompletionOptionsLine: completionsLine,
+		ExpectedCompletionOptionsLineFallbackPatterns: []*regexp.Regexp{
+			regexp.MustCompile("^" + strings.Join(escapedCompletionChoices, `\s+`) + "$"),
+		},
+		SkipPromptAssertion: true,
+		SuccessMessage:      "✓ Multiple programmable completion options listed",
+	}
+
+	if err := multiCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa9.go
+++ b/internal/stage_pa9.go
@@ -1,5 +1,111 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"strconv"
 
-func testPA9(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	randomDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	command := "git"
+	completerPath := path.Join(randomDir, "lcpEnvCompleter")
+	secret := getRandomString()
+
+	ambiguousMatches := []string{"cherry-pick", "checkout"}
+
+	prepareCompleterExecutable := func(argv1, argv2, argv3, compLine string, outputLines []string) error {
+		return (&custom_executable.CompleterExecutableSpecification{
+			Path:        completerPath,
+			SecretValue: secret,
+			CompleterConfiguration: completer_configuration.CompleterConfiguration{
+				OutputLines: outputLines,
+				ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+					Argv1: argv1,
+					Argv2: argv2,
+					Argv3: argv3,
+				},
+				ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+					CompLine:  compLine,
+					CompPoint: strconv.Itoa(len(compLine)),
+				},
+			},
+		}).Create()
+	}
+
+	// Same shape as PA6/PA7: typed partial → completion segment on the line after TAB.
+	steps := []partialAndCompleteAutocompletePair{
+		{partial: "c", complete: "che"},
+		{partial: "r", complete: "cherry-pick "},
+	}
+
+	// Line "git c": prefix "c" → LCP of checkout / cherry-pick is "che".
+	if err := prepareCompleterExecutable(
+		command,
+		steps[0].partial,
+		command,
+		fmt.Sprintf("%s %s", command, steps[0].partial),
+		ambiguousMatches,
+	); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete -C %s %s", completerPath, command)
+	registerTestCase := test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}
+	if err := registerTestCase.Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	pairs := []test_cases.InputAndCompletionPair{
+		{
+			Input:              fmt.Sprintf("%s %s", command, steps[0].partial),
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[0].complete),
+			CallbackAfterAutocompletion: func() error {
+				// Line will be "git cher" before the final TAB — unique match cherry-pick (vs checkout's "chec…").
+				return prepareCompleterExecutable(
+					command,
+					fmt.Sprintf("%s%s", steps[0].complete, steps[1].partial),
+					command,
+					fmt.Sprintf("%s %s%s", command, steps[0].complete, steps[1].partial),
+					[]string{"cherry-pick"},
+				)
+			},
+		},
+		{
+			Input:              steps[1].partial,
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[1].complete),
+		},
+	}
+
+	if err := (test_cases.PartialCompletionsTestCase{
+		InputAndCompletionPairs: pairs,
+		SuccessMessage:          "✓ Received all partial completions",
+		SkipPromptAssertion:     true,
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa9.go
+++ b/internal/stage_pa9.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -27,9 +28,7 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 	completerPath := path.Join(randomDir, "lcpEnvCompleter")
 	secret := getRandomString()
 
-	ambiguousMatches := []string{"cherry-pick", "checkout"}
-
-	prepareCompleterExecutable := func(argv1, argv2, argv3, compLine string, outputLines []string) error {
+	prepareCompleterExecutable := func(argv1, argv2, argv3, compLineEnvVar string, outputLines []string) error {
 		return (&custom_executable.CompleterExecutableSpecification{
 			Path:        completerPath,
 			SecretValue: secret,
@@ -41,26 +40,36 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 					Argv3: argv3,
 				},
 				ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
-					CompLine:  compLine,
-					CompPoint: strconv.Itoa(len(compLine)),
+					CompLine:  compLineEnvVar,
+					CompPoint: strconv.Itoa(len(compLineEnvVar)),
 				},
 			},
 		}).Create()
 	}
 
-	// Same shape as PA6/PA7: typed partial → completion segment on the line after TAB.
-	steps := []partialAndCompleteAutocompletePair{
+	lcpBranches := []struct {
+		disambiguationLetter string
+		subcommandName       string
+	}{
+		{disambiguationLetter: "c", subcommandName: "checkout"},
+		{disambiguationLetter: "r", subcommandName: "cherry-pick"},
+	}
+	chosenBranch := lcpBranches[random.RandomInt(0, len(lcpBranches))]
+
+	sortedAmbiguousSubcommands := []string{"checkout", "cherry-pick"}
+
+	partialAndCompletePairs := []partialAndCompleteAutocompletePair{
 		{partial: "c", complete: "che"},
-		{partial: "r", complete: "cherry-pick "},
+		{partial: chosenBranch.disambiguationLetter, complete: chosenBranch.subcommandName + " "},
 	}
 
-	// Line "git c": prefix "c" → LCP of checkout / cherry-pick is "che".
+	// git c -> git che (LCP Completion)
 	if err := prepareCompleterExecutable(
 		command,
-		steps[0].partial,
+		partialAndCompletePairs[0].partial,
 		command,
-		fmt.Sprintf("%s %s", command, steps[0].partial),
-		ambiguousMatches,
+		fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].partial),
+		sortedAmbiguousSubcommands,
 	); err != nil {
 		return err
 	}
@@ -78,29 +87,32 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	pairs := []test_cases.InputAndCompletionPair{
+	partialCompletionPairs := []test_cases.InputAndCompletionPair{
 		{
-			Input:              fmt.Sprintf("%s %s", command, steps[0].partial),
-			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[0].complete),
+			Input:              fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].partial),
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].complete),
+			// After the first tab completion, replace the completer script with a new script that expects
+			// the updated argv and env variables
 			CallbackAfterAutocompletion: func() error {
-				// Line will be "git cher" before the final TAB — unique match cherry-pick (vs checkout's "chec…").
+				secondTabPartialWord := fmt.Sprintf("%s%s", partialAndCompletePairs[0].complete, partialAndCompletePairs[1].partial)
+				compLineEnvVarBeforeSecondTab := fmt.Sprintf("%s %s%s", command, partialAndCompletePairs[0].complete, partialAndCompletePairs[1].partial)
 				return prepareCompleterExecutable(
 					command,
-					fmt.Sprintf("%s%s", steps[0].complete, steps[1].partial),
+					secondTabPartialWord,
 					command,
-					fmt.Sprintf("%s %s%s", command, steps[0].complete, steps[1].partial),
-					[]string{"cherry-pick"},
+					compLineEnvVarBeforeSecondTab,
+					[]string{chosenBranch.subcommandName},
 				)
 			},
 		},
 		{
-			Input:              steps[1].partial,
-			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[1].complete),
+			Input:              partialAndCompletePairs[1].partial,
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, partialAndCompletePairs[1].complete),
 		},
 	}
 
 	if err := (test_cases.PartialCompletionsTestCase{
-		InputAndCompletionPairs: pairs,
+		InputAndCompletionPairs: partialCompletionPairs,
 		SuccessMessage:          "✓ Received all partial completions",
 		SkipPromptAssertion:     true,
 	}).Run(asserter, shell, logger); err != nil {

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -104,6 +104,20 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/bash/programmable_completion/pass",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"programmable_completion_argv_incorrect": {
+			StageSlugs:          []string{"zi0"},
+			CodePath:            "./test_helpers/scenarios/programmable_completion_argv_incorrect",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/programmable_completion_argv_incorrect",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
+		"programmable_completion_envvar_incorrect": {
+			StageSlugs:          []string{"nr7"},
+			CodePath:            "./test_helpers/scenarios/programmable_completion_envvar_incorrect",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/programmable_completion_envvar_incorrect",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"background_jobs_pass_bash": {
 			StageSlugs:          []string{"af3", "at7", "si2", "jd6", "dk5", "ma9", "rq2", "bv8", "fy4"},
 			CodePath:            "./test_helpers/bash",

--- a/internal/test_cases/completion_partial_completions_test_case.go
+++ b/internal/test_cases/completion_partial_completions_test_case.go
@@ -12,6 +12,10 @@ import (
 type InputAndCompletionPair struct {
 	Input              string
 	ExpectedCompletion string
+
+	// CallbackAfterAutocompletion runs after this pair's completion assertion succeeds
+	// This field is optional
+	CallbackAfterAutocompletion func() error
 }
 
 // PartialCompletionsTestCase is a test case that does the following:
@@ -51,6 +55,12 @@ func (t PartialCompletionsTestCase) Run(asserter *logged_shell_asserter.LoggedSh
 
 		if err := t.runTabCompletionAssertion(asserter, shell, logger, t.InputAndCompletionPairs[idx]); err != nil {
 			return err
+		}
+
+		if t.InputAndCompletionPairs[idx].CallbackAfterAutocompletion != nil {
+			if err := t.InputAndCompletionPairs[idx].CallbackAfterAutocompletion(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -124,5 +134,6 @@ func (t PartialCompletionsTestCase) runTabCompletionAssertion(asserter *logged_s
 
 	// Only if we attempted to autocomplete, print the success message
 	logger.Successf("✓ Prompt line matches %q", expectedCompletion)
+
 	return nil
 }

--- a/internal/test_helpers/fixtures/bash/programmable_completion/pass
+++ b/internal/test_helpers/fixtures/bash/programmable_completion/pass
@@ -116,7 +116,7 @@ Debug = true
 
 [33m[tester::#TZ2] [0m[94mRunning tests for Stage #TZ2 (tz2)[0m
 [33m[tester::#TZ2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ complete  -C  '/tmp/pig/singleCompleter'  git[0m
+[33m[your-program] [0m[0m$ complete  -C  '/tmp/ant/singleCompleter'  git[0m
 [33m[tester::#TZ2] [0m[92m✓ Registered command-based completion[0m
 [33m[your-program] [0m[0m$ complete -r git[0m
 [33m[tester::#TZ2] [0m[92m✓ No output from complete -r[0m

--- a/internal/test_helpers/fixtures/bash/programmable_completion/pass
+++ b/internal/test_helpers/fixtures/bash/programmable_completion/pass
@@ -83,10 +83,47 @@ Debug = true
 [33m[tester::#NR7] [0m[92mTest passed.[0m
 
 [33m[tester::#EP2] [0m[94mRunning tests for Stage #EP2 (ep2)[0m
+[33m[tester::#EP2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/bee/multiCandidateEnvCompleter git[0m
+[33m[tester::#EP2] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#EP2] [0m[94mTyped "git re"[0m
+[33m[your-program] [0m[0m$ git re[0m
+[33m[tester::#EP2] [0m[92m✓ Prompt line matches "$ git re"[0m
+[33m[tester::#EP2] [0m[94mPressed "<TAB>" (expecting bell to ring)[0m
+[33m[tester::#EP2] [0m[92m✓ Received bell[0m
+[33m[tester::#EP2] [0m[94mPressed "<TAB>" (expecting "rebase  remote  reset" as completion options)[0m
+[33m[your-program] [0m[0mrebase  remote  reset[0m
+[33m[tester::#EP2] [0m[92m3 matching completion options found[0m
+[33m[tester::#EP2] [0m[92m✓ Multiple programmable completion options listed[0m
+[33m[your-program] [0m[0m$ git re[0m
 [33m[tester::#EP2] [0m[92mTest passed.[0m
 
 [33m[tester::#XZ3] [0m[94mRunning tests for Stage #XZ3 (xz3)[0m
+[33m[tester::#XZ3] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/bee/lcpEnvCompleter git[0m
+[33m[tester::#XZ3] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#XZ3] [0m[94mTyped "git c"[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git c"[0m
+[33m[tester::#XZ3] [0m[94mPressed "<TAB>" (expecting autocomplete to "git che")[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git che"[0m
+[33m[tester::#XZ3] [0m[94mTyped "r"[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git cher"[0m
+[33m[tester::#XZ3] [0m[94mPressed "<TAB>" (expecting autocomplete to "git cherry-pick" followed by a space)[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git cherry-pick "[0m
+[33m[tester::#XZ3] [0m[92m✓ Received all partial completions[0m
+[33m[your-program] [0m[0m$ git cherry-pick [0m
 [33m[tester::#XZ3] [0m[92mTest passed.[0m
 
 [33m[tester::#TZ2] [0m[94mRunning tests for Stage #TZ2 (tz2)[0m
+[33m[tester::#TZ2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete  -C  '/tmp/pig/singleCompleter'  git[0m
+[33m[tester::#TZ2] [0m[92m✓ Registered command-based completion[0m
+[33m[your-program] [0m[0m$ complete -r git[0m
+[33m[tester::#TZ2] [0m[92m✓ No output from complete -r[0m
+[33m[tester::#TZ2] [0m[94mTyped "git" followed by a <SPACE>[0m
+[33m[tester::#TZ2] [0m[92m✓ Prompt line matches "$ git "[0m
+[33m[tester::#TZ2] [0m[94mPressed "<TAB>" (expecting autocomplete to "git" followed by a space)[0m
+[33m[tester::#TZ2] [0m[92m✓ Prompt line unchanged after <TAB> press[0m
+[33m[tester::#TZ2] [0m[92m✓ Received bell[0m
+[33m[your-program] [0m[0m$ git [0m
 [33m[tester::#TZ2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/programmable_completion_argv_incorrect
+++ b/internal/test_helpers/fixtures/programmable_completion_argv_incorrect
@@ -1,0 +1,19 @@
+Debug = true
+
+[33m[tester::#ZI0] [0m[94mRunning tests for Stage #ZI0 (zi0)[0m
+[33m[tester::#ZI0] [0m[94mRunning ./your_program.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/ant/gitRemoteCompleter git[0m
+[33m[tester::#ZI0] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#ZI0] [0m[94mTyped "git remote ren"[0m
+[33m[tester::#ZI0] [0m[92m✓ Prompt line matches "$ git remote ren"[0m
+[33m[tester::#ZI0] [0m[94mPressed "<TAB>" (expecting autocomplete to "git remote rename" followed by a space)[0m
+[33m[your-program] [0m[0m$ git remote ren[0m
+[33m[tester::#ZI0] [0m[91m^ Line does not match expected value.[0m
+[33m[tester::#ZI0] [0m[91m[32mExpected:[0m "$ git remote rename "[0m
+[33m[tester::#ZI0] [0m[91m[31mReceived:[0m "$ git remote ren" [31m(no trailing space)[0m[0m
+[33m[your-program] [0m[0mError from the completer script:[0m
+[33m[your-program] [0m[0m✓ Arguments are of length 4[0m
+[33m[your-program] [0m[0m✓ Expected value of argv[1] found[0m
+[33m[your-program] [0m[0m☓ Expected argv[2] to be "ren", found "remote"[0m
+[33m[your-program] [0m[0m☓ Expected argv[3] to be "remote", found "ren"[0m
+[33m[tester::#ZI0] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/programmable_completion_envvar_incorrect
+++ b/internal/test_helpers/fixtures/programmable_completion_envvar_incorrect
@@ -1,0 +1,21 @@
+Debug = true
+
+[33m[tester::#NR7] [0m[94mRunning tests for Stage #NR7 (nr7)[0m
+[33m[tester::#NR7] [0m[94mRunning ./your_program.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/ant/gitStashCompleter git[0m
+[33m[tester::#NR7] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#NR7] [0m[94mTyped "git stash cle"[0m
+[33m[tester::#NR7] [0m[92m✓ Prompt line matches "$ git stash cle"[0m
+[33m[tester::#NR7] [0m[94mPressed "<TAB>" (expecting autocomplete to "git stash clear" followed by a space)[0m
+[33m[your-program] [0m[0m$ git stash cle[0m
+[33m[tester::#NR7] [0m[91m^ Line does not match expected value.[0m
+[33m[tester::#NR7] [0m[91m[32mExpected:[0m "$ git stash clear "[0m
+[33m[tester::#NR7] [0m[91m[31mReceived:[0m "$ git stash cle" [31m(no trailing space)[0m[0m
+[33m[your-program] [0m[0mError from the completer script:[0m
+[33m[your-program] [0m[0m✓ Arguments are of length 4[0m
+[33m[your-program] [0m[0m✓ Expected value of argv[1] found[0m
+[33m[your-program] [0m[0m✓ Expected value of argv[2] found[0m
+[33m[your-program] [0m[0m✓ Expected value of argv[3] found[0m
+[33m[your-program] [0m[0m☓ Expected environment variable COMP_LINE to be "git stash cle" found ""[0m
+[33m[your-program] [0m[0m☓ Expected environment variable COMP_POINT to be "13" found ""[0m
+[33m[tester::#NR7] [0m[91mTest failed[0m

--- a/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/codecrafters.yml
+++ b/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/main.py
+++ b/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/main.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Interactive shell for fixture recording: passes programmable-completion stages ne7–qf1 (PA1–PA5),
+fails zi0 (PA6) by invoking -C completers with argv[2] and argv[3] swapped (bash passes cmd, cur, prev).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import threading
+
+try:
+    import readline
+except ImportError:
+    readline = None  # type: ignore[misc, assignment]
+
+PROMPT = "$ "
+BUILTINS = {"echo", "exit", "type", "complete"}
+
+# command name -> completer path
+_COMPLETIONS: dict[str, str] = {}
+
+
+def _try_register_complete(line: str) -> bool:
+    """Parse `complete ... -C <path> <name>` (flexible whitespace). Returns True if handled."""
+    try:
+        parts = shlex.split(line, posix=True)
+    except ValueError:
+        return False
+    if not parts or parts[0] != "complete":
+        return False
+    i = 1
+    while i < len(parts):
+        if parts[i] == "-C" and i + 2 < len(parts):
+            path = parts[i + 1]
+            cmd = parts[i + 2]
+            _COMPLETIONS[cmd] = path
+            return True
+        i += 1
+    return False
+
+
+def _list_completions() -> None:
+    for cmd in sorted(_COMPLETIONS.keys()):
+        path = _COMPLETIONS[cmd]
+        print(f"complete -C '{path}' {cmd}")
+
+
+def _run_builtin(parts: list[str], last_exit: int) -> int | None:
+    if not parts:
+        return None
+    name = parts[0]
+    if name == "exit":
+        code = int(parts[1]) if len(parts) > 1 else last_exit
+        sys.exit(max(code, 0))
+    if name == "echo":
+        print(" ".join(parts[1:]) if len(parts) > 1 else "")
+        return None
+    if name == "type":
+        if len(parts) < 2:
+            return None
+        t = parts[1]
+        if t in BUILTINS:
+            print(f"{t} is a shell builtin")
+        else:
+            print(f"{t}: not found")
+        return None
+    if name == "complete":
+        if len(parts) == 1:
+            _list_completions()
+            return None
+        return None
+    return None
+
+
+def _find_in_path(name: str) -> str | None:
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        if not d:
+            continue
+        full = os.path.join(d, name)
+        if os.path.isfile(full) and os.access(full, os.X_OK):
+            return full
+    return None
+
+
+def _run_external(parts: list[str]) -> int:
+    exe = _find_in_path(parts[0])
+    if exe is None:
+        print(f"{parts[0]}: command not found", file=sys.stderr)
+        return 127
+    argv = [exe] + parts[1:]
+    argv[0] = parts[0]
+    p = subprocess.run(
+        argv,
+        env=os.environ,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+    return p.returncode
+
+
+def _process_line(line: str) -> int:
+    last = 0
+    line = line.strip("\n\r")
+    if not line:
+        return last
+    if _try_register_complete(line):
+        return last
+    try:
+        parts = shlex.split(line, posix=True)
+    except ValueError:
+        print(f"{line}: parse error", file=sys.stderr)
+        return 1
+    if not parts:
+        return last
+    if parts[0] in BUILTINS:
+        r = _run_builtin(parts, last)
+        return last if r is None else r
+    return _run_external(parts)
+
+
+def _programmable_completer(text: str, state: int) -> str | None:
+    if state != 0 or readline is None:
+        return None
+
+    line = readline.get_line_buffer()
+    beg = readline.get_begidx()
+    point = len(line)
+
+    before = line[:beg].rstrip()
+    if not before:
+        return None
+    words = before.split()
+    cmd = words[0]
+    if cmd not in _COMPLETIONS:
+        return None
+
+    prev = words[-1] if words else ""
+    cur = text
+
+    comp = _COMPLETIONS[cmd]
+    env = os.environ.copy()
+    env["COMP_LINE"] = line
+    env["COMP_POINT"] = str(point)
+
+    # Intentional bug: swap argv[2] (current word) and argv[3] (previous word).
+    argv_swapped = [comp, cmd, prev, cur]
+
+    # Stream completer stderr to the shell's stderr while capturing stdout for candidates.
+    # PA5 completer may sleep a long time after writing stderr; bash waits for exit.
+    proc = subprocess.Popen(
+        argv_swapped,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    err_chunks: list[str] = []
+
+    def _forward_stderr() -> None:
+        if proc.stderr is None:
+            return
+        for line in proc.stderr:
+            sys.stderr.write(line)
+            sys.stderr.flush()
+            err_chunks.append(line)
+
+    thr = threading.Thread(target=_forward_stderr, daemon=True)
+    thr.start()
+    stdout_data = proc.stdout.read() if proc.stdout else ""
+    rc = proc.wait()
+    thr.join()
+
+    out_lines = [x.strip() for x in stdout_data.splitlines() if x.strip() != ""]
+    err_text = "".join(err_chunks)
+    err_lines = [x for x in err_text.splitlines() if x.strip() != ""]
+
+    if rc != 0:
+        return None
+
+    if not out_lines and err_lines:
+        return err_lines[0]
+
+    if not out_lines:
+        sys.stdout.write("\x07")
+        sys.stdout.flush()
+        return None
+
+    matches = [x for x in out_lines if x.startswith(cur)]
+    if len(matches) == 1:
+        m = matches[0]
+        return m if m.endswith(" ") else m + " "
+    if not matches:
+        sys.stdout.write("\x07")
+        sys.stdout.flush()
+        return None
+
+    prefix = os.path.commonprefix(matches)
+    if len(prefix) > len(cur):
+        return prefix
+    sys.stdout.write("\x07")
+    sys.stdout.flush()
+    return None
+
+
+def _bind_tab_triggers_completion() -> None:
+    """Make Tab run the completer.
+
+    macOS system Python links libedit, which ignores GNU's `tab: complete` — Tab then inserts a
+    literal \\t. Binding ^I (TAB) to rl_complete works for libedit and GNU readline.
+    """
+    assert readline is not None
+    readline.parse_and_bind("bind ^I rl_complete")
+    readline.parse_and_bind("tab: complete")
+
+
+def main() -> None:
+    if readline is None:
+        print("readline is required for this scenario.", file=sys.stderr)
+        sys.exit(1)
+
+    readline.set_completer(_programmable_completer)
+    readline.set_completer_delims(" \t\n")
+    _bind_tab_triggers_completion()
+
+    last_exit = 0
+    while True:
+        try:
+            line = input(PROMPT)
+        except EOFError:
+            break
+        except KeyboardInterrupt:
+            print("^C")
+            continue
+        last_exit = _process_line(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/your_program.sh
+++ b/internal/test_helpers/scenarios/programmable_completion_argv_incorrect/your_program.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This buggy implementation of shell will pass incorrect command
+# line arguments to the completer script
+exec python3 -u "$(dirname "$0")/main.py" "$@"

--- a/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/codecrafters.yml
+++ b/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/main.py
+++ b/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/main.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Interactive shell for fixture recording: passes programmable-completion stages ne7–zi0 (PA1–PA6),
+fails nr7 (PA7) by invoking -C completers without COMP_LINE and COMP_POINT in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import threading
+
+try:
+    import readline
+except ImportError:
+    readline = None  # type: ignore[misc, assignment]
+
+PROMPT = "$ "
+BUILTINS = {"echo", "exit", "type", "complete"}
+
+# command name -> completer path
+_COMPLETIONS: dict[str, str] = {}
+
+
+def _try_register_complete(line: str) -> bool:
+    """Parse `complete ... -C <path> <name>` (flexible whitespace). Returns True if handled."""
+    try:
+        parts = shlex.split(line, posix=True)
+    except ValueError:
+        return False
+    if not parts or parts[0] != "complete":
+        return False
+    i = 1
+    while i < len(parts):
+        if parts[i] == "-C" and i + 2 < len(parts):
+            path = parts[i + 1]
+            cmd = parts[i + 2]
+            _COMPLETIONS[cmd] = path
+            return True
+        i += 1
+    return False
+
+
+def _list_completions() -> None:
+    for cmd in sorted(_COMPLETIONS.keys()):
+        path = _COMPLETIONS[cmd]
+        print(f"complete -C '{path}' {cmd}")
+
+
+def _run_builtin(parts: list[str], last_exit: int) -> int | None:
+    if not parts:
+        return None
+    name = parts[0]
+    if name == "exit":
+        code = int(parts[1]) if len(parts) > 1 else last_exit
+        sys.exit(max(code, 0))
+    if name == "echo":
+        print(" ".join(parts[1:]) if len(parts) > 1 else "")
+        return None
+    if name == "type":
+        if len(parts) < 2:
+            return None
+        t = parts[1]
+        if t in BUILTINS:
+            print(f"{t} is a shell builtin")
+        else:
+            print(f"{t}: not found")
+        return None
+    if name == "complete":
+        if len(parts) == 1:
+            _list_completions()
+            return None
+        return None
+    return None
+
+
+def _find_in_path(name: str) -> str | None:
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        if not d:
+            continue
+        full = os.path.join(d, name)
+        if os.path.isfile(full) and os.access(full, os.X_OK):
+            return full
+    return None
+
+
+def _run_external(parts: list[str]) -> int:
+    exe = _find_in_path(parts[0])
+    if exe is None:
+        print(f"{parts[0]}: command not found", file=sys.stderr)
+        return 127
+    argv = [exe] + parts[1:]
+    argv[0] = parts[0]
+    p = subprocess.run(
+        argv,
+        env=os.environ,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+    return p.returncode
+
+
+def _process_line(line: str) -> int:
+    last = 0
+    line = line.strip("\n\r")
+    if not line:
+        return last
+    if _try_register_complete(line):
+        return last
+    try:
+        parts = shlex.split(line, posix=True)
+    except ValueError:
+        print(f"{line}: parse error", file=sys.stderr)
+        return 1
+    if not parts:
+        return last
+    if parts[0] in BUILTINS:
+        r = _run_builtin(parts, last)
+        return last if r is None else r
+    return _run_external(parts)
+
+
+def _programmable_completer(text: str, state: int) -> str | None:
+    if state != 0 or readline is None:
+        return None
+
+    line = readline.get_line_buffer()
+    beg = readline.get_begidx()
+    point = len(line)
+
+    before = line[:beg].rstrip()
+    if not before:
+        return None
+    words = before.split()
+    cmd = words[0]
+    if cmd not in _COMPLETIONS:
+        return None
+
+    prev = words[-1] if words else ""
+    cur = text
+
+    comp = _COMPLETIONS[cmd]
+    # Intentional bug: do not pass COMP_LINE / COMP_POINT (bash sets these for -C completers).
+    env = os.environ.copy()
+    env.pop("COMP_LINE", None)
+    env.pop("COMP_POINT", None)
+
+    argv = [comp, cmd, cur, prev]
+
+    # Stream completer stderr to the shell's stderr while capturing stdout for candidates.
+    # PA5 completer may sleep a long time after writing stderr; bash waits for exit.
+    proc = subprocess.Popen(
+        argv,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    err_chunks: list[str] = []
+
+    def _forward_stderr() -> None:
+        if proc.stderr is None:
+            return
+        for line in proc.stderr:
+            sys.stderr.write(line)
+            sys.stderr.flush()
+            err_chunks.append(line)
+
+    thr = threading.Thread(target=_forward_stderr, daemon=True)
+    thr.start()
+    stdout_data = proc.stdout.read() if proc.stdout else ""
+    rc = proc.wait()
+    thr.join()
+
+    out_lines = [x.strip() for x in stdout_data.splitlines() if x.strip() != ""]
+    err_text = "".join(err_chunks)
+    err_lines = [x for x in err_text.splitlines() if x.strip() != ""]
+
+    if rc != 0:
+        return None
+
+    if not out_lines and err_lines:
+        return err_lines[0]
+
+    if not out_lines:
+        sys.stdout.write("\x07")
+        sys.stdout.flush()
+        return None
+
+    matches = [x for x in out_lines if x.startswith(cur)]
+    if len(matches) == 1:
+        m = matches[0]
+        return m if m.endswith(" ") else m + " "
+    if not matches:
+        sys.stdout.write("\x07")
+        sys.stdout.flush()
+        return None
+
+    prefix = os.path.commonprefix(matches)
+    if len(prefix) > len(cur):
+        return prefix
+    sys.stdout.write("\x07")
+    sys.stdout.flush()
+    return None
+
+
+def _bind_tab_triggers_completion() -> None:
+    """Make Tab run the completer.
+
+    macOS system Python links libedit, which ignores GNU's `tab: complete` — Tab then inserts a
+    literal \\t. Binding ^I (TAB) to rl_complete works for libedit and GNU readline.
+    """
+    assert readline is not None
+    readline.parse_and_bind("bind ^I rl_complete")
+    readline.parse_and_bind("tab: complete")
+
+
+def main() -> None:
+    if readline is None:
+        print("readline is required for this scenario.", file=sys.stderr)
+        sys.exit(1)
+
+    readline.set_completer(_programmable_completer)
+    readline.set_completer_delims(" \t\n")
+    _bind_tab_triggers_completion()
+
+    last_exit = 0
+    while True:
+        try:
+            line = input(PROMPT)
+        except EOFError:
+            break
+        except KeyboardInterrupt:
+            print("^C")
+            continue
+        last_exit = _process_line(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/your_program.sh
+++ b/internal/test_helpers/scenarios/programmable_completion_envvar_incorrect/your_program.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Buggy shell: programmable completion invokes -C completers with correct argv but omits
+# COMP_LINE and COMP_POINT from the completer's environment.
+exec python3 -u "$(dirname "$0")/main.py" "$@"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: updates core programmable-completion stage tests and introduces new test-case callback behavior, which could cause flakiness or alter stage expectations if the shell/TTY interactions differ across environments.
> 
> **Overview**
> Adds full implementations for programmable-completion stages **PA8–PA10**: multi-candidate listing on double-tab (PA8), longest-common-prefix then disambiguation across successive tabs (PA9), and ensuring `complete -r` unregisters completions and tab now only rings the bell (PA10).
> 
> Extends `PartialCompletionsTestCase` to support an optional `CallbackAfterAutocompletion`, enabling tests to mutate the completer between tab presses (used by PA9).
> 
> Adds new regression scenarios + fixtures that intentionally fail when a shell passes incorrect `argv` to `-C` completers (swapped `cur`/`prev`) or omits `COMP_LINE`/`COMP_POINT`, and wires these into `stages_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d67ba9e1b59114ec1c06d499ff6323705ec189f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->