### PR TITLE
Programmable Completion (Stage 8-10)

### DIFF
--- a/internal/stage_pa10.go
+++ b/internal/stage_pa10.go
@@ -1,5 +1,91 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"strconv"
 
-func testPA10(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testPA10(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	completerDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	commandName := "git"
+	completerPath := path.Join(completerDir, "singleCompleter")
+
+	completionSubcommand := random.RandomElementFromArray(
+		[]string{"clone", "add", "commit", "push"},
+	)
+
+	compLine := commandName + " "
+	compPoint := strconv.Itoa(len(compLine))
+
+	// We need not use a valid completer here, but a valid completer makes it
+	// obvious in the error messages
+	// that the completion script was run when it shouldn't have
+	if err := (&custom_executable.CompleterExecutableSpecification{
+		Path:        completerPath,
+		SecretValue: getRandomString(),
+		CompleterConfiguration: completer_configuration.CompleterConfiguration{
+			OutputLines: []string{completionSubcommand},
+			ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+				Argv1: commandName,
+				Argv2: "",
+				Argv3: commandName,
+			},
+			ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+				CompLine:  compLine,
+				CompPoint: compPoint,
+			},
+		},
+	}).Create(); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete  -C  '%s'  %s", completerPath, commandName)
+
+	if err := (test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}).Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	unregisterCmd := fmt.Sprintf("complete -r %s", commandName)
+
+	if err := (test_cases.CommandWithNoResponseTestCase{
+		Command:        unregisterCmd,
+		SuccessMessage: "✓ No output from complete -r",
+	}).Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	if err := (test_cases.AutocompleteTestCase{
+		RawInput:            commandName + " ",
+		ExpectedCompletion:  commandName + " ",
+		CheckForBell:        true,
+		SkipPromptAssertion: true,
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa8.go
+++ b/internal/stage_pa8.go
@@ -1,5 +1,113 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
-func testPA8(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+// gitMultiSubcommandChoice drives top-level `git <subcommand>` completion only (no nested words).
+// Completion strings are chosen so bash does not extend a longest-common-prefix past what the
+// user already typed: either they share no common prefix (empty partial), or their LCP equals partial.
+type gitMultiSubcommandChoice struct {
+	partial     string
+	completions []string
+}
+
+func testPA8(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	randomDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	command := "git"
+
+	// The partial script should not accidentally trigger LCP for this stage
+	// So we choose completions with no common remaining prefix
+	choices := []gitMultiSubcommandChoice{
+		{partial: "che", completions: []string{"checkout", "cherry-pick"}},
+		{partial: "re", completions: []string{"reset", "remote", "rebase"}},
+		{partial: "pu", completions: []string{"push", "pull"}},
+		{partial: "sta", completions: []string{"stash", "status"}},
+	}
+
+	choice := choices[random.RandomInt(0, len(choices))]
+
+	sortedCompletions := append([]string(nil), choice.completions...)
+	sort.Strings(sortedCompletions)
+
+	compLineEnvVar := fmt.Sprintf("%s %s", command, choice.partial)
+	completionsLine := strings.Join(sortedCompletions, "  ")
+
+	completerPath := path.Join(randomDir, "multiCandidateEnvCompleter")
+
+	if err := (&custom_executable.CompleterExecutableSpecification{
+		Path:        completerPath,
+		SecretValue: getRandomString(),
+		CompleterConfiguration: completer_configuration.CompleterConfiguration{
+			OutputLines: sortedCompletions,
+			ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+				Argv1: command,
+				Argv2: choice.partial,
+				Argv3: command,
+			},
+			ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+				CompLine:  compLineEnvVar,
+				CompPoint: strconv.Itoa(len(compLineEnvVar)),
+			},
+		},
+	}).Create(); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete -C %s %s", completerPath, command)
+	registerTestCase := test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}
+	if err := registerTestCase.Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	escapedCompletionChoices := make([]string, len(sortedCompletions))
+	for i, name := range sortedCompletions {
+		escapedCompletionChoices[i] = regexp.QuoteMeta(name)
+	}
+
+	multiCase := test_cases.MultipleCompletionsTestCase{
+		RawInput:                      compLineEnvVar,
+		TabCount:                      2,
+		CheckForBell:                  true,
+		ExpectedCompletionOptionsLine: completionsLine,
+		ExpectedCompletionOptionsLineFallbackPatterns: []*regexp.Regexp{
+			regexp.MustCompile("^" + strings.Join(escapedCompletionChoices, `\s+`) + "$"),
+		},
+		SkipPromptAssertion: true,
+		SuccessMessage:      "✓ Multiple programmable completion options listed",
+	}
+
+	if err := multiCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa9.go
+++ b/internal/stage_pa9.go
@@ -1,5 +1,111 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"path"
+	"strconv"
 
-func testPA9(_ *test_case_harness.TestCaseHarness) error { return nil }
+	custom_executable "github.com/codecrafters-io/shell-tester/internal/custom_executable/build"
+	"github.com/codecrafters-io/shell-tester/internal/custom_executable/completer/completer_configuration"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	randomDir, err := CreateShortRandomDirInTmp(stageHarness)
+	if err != nil {
+		return err
+	}
+
+	command := "git"
+	completerPath := path.Join(randomDir, "lcpEnvCompleter")
+	secret := getRandomString()
+
+	ambiguousMatches := []string{"cherry-pick", "checkout"}
+
+	prepareCompleterExecutable := func(argv1, argv2, argv3, compLine string, outputLines []string) error {
+		return (&custom_executable.CompleterExecutableSpecification{
+			Path:        completerPath,
+			SecretValue: secret,
+			CompleterConfiguration: completer_configuration.CompleterConfiguration{
+				OutputLines: outputLines,
+				ExpectedArguments: &completer_configuration.CompleterConfigurationExpectedArguments{
+					Argv1: argv1,
+					Argv2: argv2,
+					Argv3: argv3,
+				},
+				ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
+					CompLine:  compLine,
+					CompPoint: strconv.Itoa(len(compLine)),
+				},
+			},
+		}).Create()
+	}
+
+	// Same shape as PA6/PA7: typed partial → completion segment on the line after TAB.
+	steps := []partialAndCompleteAutocompletePair{
+		{partial: "c", complete: "che"},
+		{partial: "r", complete: "cherry-pick "},
+	}
+
+	// Line "git c": prefix "c" → LCP of checkout / cherry-pick is "che".
+	if err := prepareCompleterExecutable(
+		command,
+		steps[0].partial,
+		command,
+		fmt.Sprintf("%s %s", command, steps[0].partial),
+		ambiguousMatches,
+	); err != nil {
+		return err
+	}
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	registerCmd := fmt.Sprintf("complete -C %s %s", completerPath, command)
+	registerTestCase := test_cases.CommandWithNoResponseTestCase{
+		Command:        registerCmd,
+		SuccessMessage: "✓ Registered command-based completion",
+	}
+	if err := registerTestCase.Run(asserter, shell, logger, false); err != nil {
+		return err
+	}
+
+	pairs := []test_cases.InputAndCompletionPair{
+		{
+			Input:              fmt.Sprintf("%s %s", command, steps[0].partial),
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[0].complete),
+			CallbackAfterAutocompletion: func() error {
+				// Line will be "git cher" before the final TAB — unique match cherry-pick (vs checkout's "chec…").
+				return prepareCompleterExecutable(
+					command,
+					fmt.Sprintf("%s%s", steps[0].complete, steps[1].partial),
+					command,
+					fmt.Sprintf("%s %s%s", command, steps[0].complete, steps[1].partial),
+					[]string{"cherry-pick"},
+				)
+			},
+		},
+		{
+			Input:              steps[1].partial,
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[1].complete),
+		},
+	}
+
+	if err := (test_cases.PartialCompletionsTestCase{
+		InputAndCompletionPairs: pairs,
+		SuccessMessage:          "✓ Received all partial completions",
+		SkipPromptAssertion:     true,
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
+}

--- a/internal/stage_pa9.go
+++ b/internal/stage_pa9.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
 	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -27,9 +28,7 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 	completerPath := path.Join(randomDir, "lcpEnvCompleter")
 	secret := getRandomString()
 
-	ambiguousMatches := []string{"cherry-pick", "checkout"}
-
-	prepareCompleterExecutable := func(argv1, argv2, argv3, compLine string, outputLines []string) error {
+	prepareCompleterExecutable := func(argv1, argv2, argv3, compLineEnvVar string, outputLines []string) error {
 		return (&custom_executable.CompleterExecutableSpecification{
 			Path:        completerPath,
 			SecretValue: secret,
@@ -41,26 +40,36 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 					Argv3: argv3,
 				},
 				ExpectedEnvVars: &completer_configuration.CompleterConfigurationEnvVars{
-					CompLine:  compLine,
-					CompPoint: strconv.Itoa(len(compLine)),
+					CompLine:  compLineEnvVar,
+					CompPoint: strconv.Itoa(len(compLineEnvVar)),
 				},
 			},
 		}).Create()
 	}
 
-	// Same shape as PA6/PA7: typed partial → completion segment on the line after TAB.
-	steps := []partialAndCompleteAutocompletePair{
+	lcpBranches := []struct {
+		disambiguationLetter string
+		subcommandName       string
+	}{
+		{disambiguationLetter: "c", subcommandName: "checkout"},
+		{disambiguationLetter: "r", subcommandName: "cherry-pick"},
+	}
+	chosenBranch := lcpBranches[random.RandomInt(0, len(lcpBranches))]
+
+	sortedAmbiguousSubcommands := []string{"checkout", "cherry-pick"}
+
+	partialAndCompletePairs := []partialAndCompleteAutocompletePair{
 		{partial: "c", complete: "che"},
-		{partial: "r", complete: "cherry-pick "},
+		{partial: chosenBranch.disambiguationLetter, complete: chosenBranch.subcommandName + " "},
 	}
 
-	// Line "git c": prefix "c" → LCP of checkout / cherry-pick is "che".
+	// git c -> git che (LCP Completion)
 	if err := prepareCompleterExecutable(
 		command,
-		steps[0].partial,
+		partialAndCompletePairs[0].partial,
 		command,
-		fmt.Sprintf("%s %s", command, steps[0].partial),
-		ambiguousMatches,
+		fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].partial),
+		sortedAmbiguousSubcommands,
 	); err != nil {
 		return err
 	}
@@ -78,29 +87,32 @@ func testPA9(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	pairs := []test_cases.InputAndCompletionPair{
+	partialCompletionPairs := []test_cases.InputAndCompletionPair{
 		{
-			Input:              fmt.Sprintf("%s %s", command, steps[0].partial),
-			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[0].complete),
+			Input:              fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].partial),
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, partialAndCompletePairs[0].complete),
+			// After the first tab completion, replace the completer script with a new script that expects
+			// the updated argv and env variables
 			CallbackAfterAutocompletion: func() error {
-				// Line will be "git cher" before the final TAB — unique match cherry-pick (vs checkout's "chec…").
+				secondTabPartialWord := fmt.Sprintf("%s%s", partialAndCompletePairs[0].complete, partialAndCompletePairs[1].partial)
+				compLineEnvVarBeforeSecondTab := fmt.Sprintf("%s %s%s", command, partialAndCompletePairs[0].complete, partialAndCompletePairs[1].partial)
 				return prepareCompleterExecutable(
 					command,
-					fmt.Sprintf("%s%s", steps[0].complete, steps[1].partial),
+					secondTabPartialWord,
 					command,
-					fmt.Sprintf("%s %s%s", command, steps[0].complete, steps[1].partial),
-					[]string{"cherry-pick"},
+					compLineEnvVarBeforeSecondTab,
+					[]string{chosenBranch.subcommandName},
 				)
 			},
 		},
 		{
-			Input:              steps[1].partial,
-			ExpectedCompletion: fmt.Sprintf("%s %s", command, steps[1].complete),
+			Input:              partialAndCompletePairs[1].partial,
+			ExpectedCompletion: fmt.Sprintf("%s %s", command, partialAndCompletePairs[1].complete),
 		},
 	}
 
 	if err := (test_cases.PartialCompletionsTestCase{
-		InputAndCompletionPairs: pairs,
+		InputAndCompletionPairs: partialCompletionPairs,
 		SuccessMessage:          "✓ Received all partial completions",
 		SkipPromptAssertion:     true,
 	}).Run(asserter, shell, logger); err != nil {

--- a/internal/test_cases/completion_partial_completions_test_case.go
+++ b/internal/test_cases/completion_partial_completions_test_case.go
@@ -12,6 +12,10 @@ import (
 type InputAndCompletionPair struct {
 	Input              string
 	ExpectedCompletion string
+
+	// CallbackAfterAutocompletion runs after this pair's completion assertion succeeds
+	// This field is optional
+	CallbackAfterAutocompletion func() error
 }
 
 // PartialCompletionsTestCase is a test case that does the following:
@@ -51,6 +55,12 @@ func (t PartialCompletionsTestCase) Run(asserter *logged_shell_asserter.LoggedSh
 
 		if err := t.runTabCompletionAssertion(asserter, shell, logger, t.InputAndCompletionPairs[idx]); err != nil {
 			return err
+		}
+
+		if t.InputAndCompletionPairs[idx].CallbackAfterAutocompletion != nil {
+			if err := t.InputAndCompletionPairs[idx].CallbackAfterAutocompletion(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -124,5 +134,6 @@ func (t PartialCompletionsTestCase) runTabCompletionAssertion(asserter *logged_s
 
 	// Only if we attempted to autocomplete, print the success message
 	logger.Successf("✓ Prompt line matches %q", expectedCompletion)
+
 	return nil
 }

--- a/internal/test_helpers/fixtures/bash/programmable_completion/pass
+++ b/internal/test_helpers/fixtures/bash/programmable_completion/pass
@@ -116,7 +116,7 @@ Debug = true
 
 [33m[tester::#TZ2] [0m[94mRunning tests for Stage #TZ2 (tz2)[0m
 [33m[tester::#TZ2] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ complete  -C  '/tmp/pig/singleCompleter'  git[0m
+[33m[your-program] [0m[0m$ complete  -C  '/tmp/ant/singleCompleter'  git[0m
 [33m[tester::#TZ2] [0m[92m✓ Registered command-based completion[0m
 [33m[your-program] [0m[0m$ complete -r git[0m
 [33m[tester::#TZ2] [0m[92m✓ No output from complete -r[0m

--- a/internal/test_helpers/fixtures/bash/programmable_completion/pass
+++ b/internal/test_helpers/fixtures/bash/programmable_completion/pass
@@ -83,10 +83,47 @@ Debug = true
 [33m[tester::#NR7] [0m[92mTest passed.[0m
 
 [33m[tester::#EP2] [0m[94mRunning tests for Stage #EP2 (ep2)[0m
+[33m[tester::#EP2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/bee/multiCandidateEnvCompleter git[0m
+[33m[tester::#EP2] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#EP2] [0m[94mTyped "git re"[0m
+[33m[your-program] [0m[0m$ git re[0m
+[33m[tester::#EP2] [0m[92m✓ Prompt line matches "$ git re"[0m
+[33m[tester::#EP2] [0m[94mPressed "<TAB>" (expecting bell to ring)[0m
+[33m[tester::#EP2] [0m[92m✓ Received bell[0m
+[33m[tester::#EP2] [0m[94mPressed "<TAB>" (expecting "rebase  remote  reset" as completion options)[0m
+[33m[your-program] [0m[0mrebase  remote  reset[0m
+[33m[tester::#EP2] [0m[92m3 matching completion options found[0m
+[33m[tester::#EP2] [0m[92m✓ Multiple programmable completion options listed[0m
+[33m[your-program] [0m[0m$ git re[0m
 [33m[tester::#EP2] [0m[92mTest passed.[0m
 
 [33m[tester::#XZ3] [0m[94mRunning tests for Stage #XZ3 (xz3)[0m
+[33m[tester::#XZ3] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete -C /tmp/bee/lcpEnvCompleter git[0m
+[33m[tester::#XZ3] [0m[92m✓ Registered command-based completion[0m
+[33m[tester::#XZ3] [0m[94mTyped "git c"[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git c"[0m
+[33m[tester::#XZ3] [0m[94mPressed "<TAB>" (expecting autocomplete to "git che")[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git che"[0m
+[33m[tester::#XZ3] [0m[94mTyped "r"[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git cher"[0m
+[33m[tester::#XZ3] [0m[94mPressed "<TAB>" (expecting autocomplete to "git cherry-pick" followed by a space)[0m
+[33m[tester::#XZ3] [0m[92m✓ Prompt line matches "$ git cherry-pick "[0m
+[33m[tester::#XZ3] [0m[92m✓ Received all partial completions[0m
+[33m[your-program] [0m[0m$ git cherry-pick [0m
 [33m[tester::#XZ3] [0m[92mTest passed.[0m
 
 [33m[tester::#TZ2] [0m[94mRunning tests for Stage #TZ2 (tz2)[0m
+[33m[tester::#TZ2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ complete  -C  '/tmp/pig/singleCompleter'  git[0m
+[33m[tester::#TZ2] [0m[92m✓ Registered command-based completion[0m
+[33m[your-program] [0m[0m$ complete -r git[0m
+[33m[tester::#TZ2] [0m[92m✓ No output from complete -r[0m
+[33m[tester::#TZ2] [0m[94mTyped "git" followed by a <SPACE>[0m
+[33m[tester::#TZ2] [0m[92m✓ Prompt line matches "$ git "[0m
+[33m[tester::#TZ2] [0m[94mPressed "<TAB>" (expecting autocomplete to "git" followed by a space)[0m
+[33m[tester::#TZ2] [0m[92m✓ Prompt line unchanged after <TAB> press[0m
+[33m[tester::#TZ2] [0m[92m✓ Received bell[0m
+[33m[your-program] [0m[0m$ git [0m
 [33m[tester::#TZ2] [0m[92mTest passed.[0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily test-only changes, but the new `CallbackAfterAutocompletion` execution path can affect any existing uses of `PartialCompletionsTestCase` and may introduce flakiness if callbacks or completer rewrites fail.
> 
> **Overview**
> Adds coverage for programmable completion stages *PA8–PA10* by replacing placeholder tests with real end-to-end shell interactions that build and register custom `complete -C` executables, then assert behaviors for multiple candidates (double-tab listing + bell), longest-common-prefix expansion across successive TAB presses, and completion unregistration via `complete -r`.
> 
> Extends `PartialCompletionsTestCase` with an optional `CallbackAfterAutocompletion` hook so tests can mutate/replace the completer between completion steps, and updates the bash programmable-completion fixture output to include the new stages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d9bc70c5926303164b03fa6eae8c7b08502921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->