### PR TITLE
Utils named return shadowing

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -78,16 +78,18 @@ func LogReadableFileContents(l *logger.Logger, fileContents string, logMsg strin
 }
 
 func MustGetAbsolutePathOfCommand(command string) (absolutePath string) {
+	var err error
+
 	// For fixtures, it's always busybox
 	if testing.IsRecordingOrEvaluatingFixtures() {
-		absolutePath, err := executable.ResolveAbsolutePath("busybox")
+		absolutePath, err = executable.ResolveAbsolutePath("busybox")
 		if err != nil {
 			panic(fmt.Sprintf("Codecrafters Internal Error - Failed to resolve absolute path for command %s", command))
 		}
 		return absolutePath
 	}
 
-	absolutePath, err := executable.ResolveAbsolutePath(command)
+	absolutePath, err = executable.ResolveAbsolutePath(command)
 
 	if err != nil {
 		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to resolve absolute path for command %s", command))


### PR DESCRIPTION
Fixes a potential bug where a named return variable was shadowed, ensuring direct assignment to prevent future silent failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small bugfix that changes local variable assignment to ensure the named return `absolutePath` is set correctly; behavior should only improve in error-prone cases.
> 
> **Overview**
> Fixes `MustGetAbsolutePathOfCommand` to avoid shadowing its named return variable by declaring `err` once and using `absolutePath, err = ...` assignments (including the fixtures `busybox` path), preventing accidental returns of an unset `absolutePath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f732392eca16a48e7ab701938c03110f758940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->