### PR TITLE
Add executable path check for background process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d
-	github.com/codecrafters-io/tester-utils v0.4.17
+	github.com/codecrafters-io/tester-utils v0.4.18
 	github.com/creack/pty v1.1.24
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d h1:cIxw4y+aEGux
 github.com/charmbracelet/x/vt v0.0.0-20250122132629-a969ddeb820d/go.mod h1:RB6f81fnGXyFGRenuO1fMdTlBh0Dbp/0+jwiMtgZvJw=
 github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91 h1:D5OO0lVavz7A+Swdhp62F9gbkibxmz9B2hZ/jVdMPf0=
 github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91/go.mod h1:Ey8PFmYwH+/td9bpiEx07Fdx9ZVkxfIjWXxBluxF4Nw=
-github.com/codecrafters-io/tester-utils v0.4.17 h1:1vpkUOGfvKNOeokL9UiIA4O7zQljT5KDG78dTzm2ojM=
-github.com/codecrafters-io/tester-utils v0.4.17/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.18 h1:8NYviQTSaBNOhTyu51EVh9SljyXkfr9rQTOp2o39Nv0=
+github.com/codecrafters-io/tester-utils v0.4.18/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -278,10 +278,11 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"[your-program] [JOB_NUM] PID":                    {regexp.MustCompile(`\[your-program\].*\[\d+\] \d+`)},
 		"[tester::#STAGE] ✓ Found process with PID <PID>": {regexp.MustCompile(`\[tester::#[A-Z]{2}\d+\].*Found process with PID \d+`)},
 		// For background_jobs error cases
-		"[your-program] [JOB_NUM]PID":                {regexp.MustCompile(`\[your-program\].*\[\d+\]\d+`)},
-		"[tester::#AT7] Received: \"[JOB_NUM]PID\"":  {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\]\d+"`)},
-		"[tester::#AT7] Received: \"[JOB_NUM] PID\"": {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\] \d+"`)},
-		"[tester::#FY4] Received: \"[JOB_NUM] PID\"": {regexp.MustCompile(`\[tester::#FY4\].*Received:.*"\[\d+\] \d+"`)},
+		"[your-program] [JOB_NUM]PID":                               {regexp.MustCompile(`\[your-program\].*\[\d+\]\d+`)},
+		"[tester::#AT7] Received: \"[JOB_NUM]PID\"":                 {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\]\d+"`)},
+		"[tester::#AT7] Received: \"[JOB_NUM] PID\"":                {regexp.MustCompile(`\[tester::#AT7\].*Received:.*"\[\d+\] \d+"`)},
+		"[tester::#FY4] Received: \"[JOB_NUM] PID\"":                {regexp.MustCompile(`\[tester::#FY4\].*Received:.*"\[\d+\] \d+"`)},
+		"Expected executable path found for process with PID <PID>": {regexp.MustCompile(`Expected executable path found for process with PID \d+`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -167,6 +167,13 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_middleware_launch",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"background_jobs_wrong_executable_path": {
+			StageSlugs:          []string{"at7"},
+			CodePath:            "./test_helpers/scenarios/background_jobs_wrong_executable",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/background_jobs_wrong_executable",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"pipelines_pass_bash": {
 			StageSlugs:          []string{"br6", "ny9", "xk3"},
 			CodePath:            "./test_helpers/bash",

--- a/internal/test_cases/background_command_response_test_case.go
+++ b/internal/test_cases/background_command_response_test_case.go
@@ -9,7 +9,10 @@ import (
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
 	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
+	"github.com/google/shlex"
+	"github.com/shirou/gopsutil/v3/process"
 )
 
 // BackgroundCommandResponseTestCase launches the given command with an & symbol
@@ -81,9 +84,39 @@ func (t *BackgroundCommandResponseTestCase) Run(asserter *logged_shell_asserter.
 
 	logger.Successf("✓ Found process with PID %d", receivedPid)
 
+	if err := t.checkBackgroundCommandExecutablePath(receivedPid); err != nil {
+		return err
+	}
+
+	logger.Successf("✓ Expected executable path found for process with PID %d", receivedPid)
+
 	if t.SuccessMessage != "" {
 		logger.Successf("%s", t.SuccessMessage)
 	}
 
+	return nil
+}
+
+func (t *BackgroundCommandResponseTestCase) checkBackgroundCommandExecutablePath(pid int) error {
+	bgProcess, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return fmt.Errorf("Failed to extract process information on PID %d: %s", pid, err)
+	}
+
+	receivedExecutablePath, err := bgProcess.Exe()
+	if err != nil {
+		return fmt.Errorf("Failed to extract executable path for PID %d: %s", pid, err)
+	}
+
+	cmdlineArgs, err := shlex.Split(t.Command)
+	if err != nil {
+		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to extract arguments for command %s: %s", t.Command, err))
+	}
+
+	argv0 := cmdlineArgs[0]
+	expectedExecutablePath := utils.MustGetExecutablePathForCommand(argv0)
+	if receivedExecutablePath != expectedExecutablePath {
+		return fmt.Errorf("Expected executable path for %s to be %s, got %s", t.Command, expectedExecutablePath, receivedExecutablePath)
+	}
 	return nil
 }

--- a/internal/test_cases/background_command_response_test_case.go
+++ b/internal/test_cases/background_command_response_test_case.go
@@ -110,7 +110,7 @@ func (t *BackgroundCommandResponseTestCase) checkBackgroundCommandExecutablePath
 
 	cmdlineArgs, err := shlex.Split(t.Command)
 	if err != nil {
-		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to extract arguments for command %s: %s", t.Command, err))
+		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to extract executable path for command %s: %s", t.Command, err))
 	}
 
 	argv0 := cmdlineArgs[0]

--- a/internal/test_cases/background_command_response_test_case.go
+++ b/internal/test_cases/background_command_response_test_case.go
@@ -100,12 +100,12 @@ func (t *BackgroundCommandResponseTestCase) Run(asserter *logged_shell_asserter.
 func (t *BackgroundCommandResponseTestCase) checkBackgroundCommandExecutablePath(pid int) error {
 	bgProcess, err := process.NewProcess(int32(pid))
 	if err != nil {
-		return fmt.Errorf("Failed to extract process information on PID %d: %s", pid, err)
+		return fmt.Errorf("Failed to extract process information on process with PID %d: %s", pid, err)
 	}
 
 	receivedExecutablePath, err := bgProcess.Exe()
 	if err != nil {
-		return fmt.Errorf("Failed to extract executable path for PID %d: %s", pid, err)
+		return fmt.Errorf("Failed to extract arguments for process with PID %d: %s", pid, err)
 	}
 
 	cmdlineArgs, err := shlex.Split(t.Command)
@@ -114,9 +114,17 @@ func (t *BackgroundCommandResponseTestCase) checkBackgroundCommandExecutablePath
 	}
 
 	argv0 := cmdlineArgs[0]
-	expectedExecutablePath := utils.MustGetExecutablePathForCommand(argv0)
-	if receivedExecutablePath != expectedExecutablePath {
-		return fmt.Errorf("Expected executable path for %s to be %s, got %s", t.Command, expectedExecutablePath, receivedExecutablePath)
+	expectedExecutableAbsPath, expectedExecutableResolvedSymlinkPath :=
+		utils.MustGetExecutablePathAndResolvedSymlinkForCommand(argv0)
+
+	// If the received executable path is neither the absolute path or the resolved symlink, raise an error
+	if !slices.Contains(
+		[]string{expectedExecutableAbsPath, expectedExecutableResolvedSymlinkPath},
+		receivedExecutablePath,
+	) {
+		// The error message should contain the unresolved symlink
+		return fmt.Errorf("Expected executable path for %s to be %q, got %q", argv0, expectedExecutableAbsPath, receivedExecutablePath)
 	}
+
 	return nil
 }

--- a/internal/test_cases/background_command_response_test_case.go
+++ b/internal/test_cases/background_command_response_test_case.go
@@ -105,12 +105,12 @@ func (t *BackgroundCommandResponseTestCase) checkBackgroundCommandExecutablePath
 
 	receivedExecutablePath, err := bgProcess.Exe()
 	if err != nil {
-		return fmt.Errorf("Failed to extract arguments for process with PID %d: %s", pid, err)
+		return fmt.Errorf("Failed to extract executable path for process with PID %d: %s", pid, err)
 	}
 
 	cmdlineArgs, err := shlex.Split(t.Command)
 	if err != nil {
-		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to extract executable path for command %s: %s", t.Command, err))
+		panic(fmt.Sprintf("Codecrafters Internal Error - Failed to extract arguments for command %s: %s", t.Command, err))
 	}
 
 	argv0 := cmdlineArgs[0]

--- a/internal/test_helpers/fixtures/background_jobs_extra_ampersand
+++ b/internal/test_helpers/fixtures/background_jobs_extra_ampersand
@@ -4,8 +4,9 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_program.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[your-program] [0m[0m$ cat /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2405[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2405[0m
+[33m[your-program] [0m[0m[1] 2748[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2748[0m
+[33m[tester::#MA9] [0m[92m✓ Expected executable path found for process with PID 2748[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                 cat /tmp/pear-70 &[0m

--- a/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
+++ b/internal/test_helpers/fixtures/background_jobs_job_number_not_recycled
@@ -4,8 +4,9 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/pear-70[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/pear-70 &[0m
-[33m[your-program] [0m[0m[1] 2518[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2518[0m
+[33m[your-program] [0m[0m[1] 2742[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2742[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2742[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/pear-70"[0m
 [33m[your-program] [0m[0m$ echo orange[0m
@@ -18,9 +19,9 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[2] 2521[0m
+[33m[your-program] [0m[0m[2] 2745[0m
 [33m[tester::#FY4] [0m[91m^ Line does not match expected value.[0m
 [33m[tester::#FY4] [0m[91m[32mExpected:[0m "[1] <PID>"[0m
-[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2521"[0m
+[33m[tester::#FY4] [0m[91m[31mReceived:[0m "[2] 2745"[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#FY4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/background_jobs_jobs_builtin_incorrect_marker
+++ b/internal/test_helpers/fixtures/background_jobs_jobs_builtin_incorrect_marker
@@ -3,8 +3,9 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2261[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2261[0m
+[33m[your-program] [0m[0m[1] 2394[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2394[0m
+[33m[tester::#DK5] [0m[92m✓ Expected executable path found for process with PID 2394[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                 sleep 100 &[0m

--- a/internal/test_helpers/fixtures/background_jobs_jobs_builtin_incorrect_output_format
+++ b/internal/test_helpers/fixtures/background_jobs_jobs_builtin_incorrect_output_format
@@ -3,8 +3,9 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2498[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2498[0m
+[33m[your-program] [0m[0m[1] 2477[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2477[0m
+[33m[tester::#DK5] [0m[92m✓ Expected executable path found for process with PID 2477[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+Running                 sleep 100 &[0m

--- a/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
+++ b/internal/test_helpers/fixtures/background_jobs_jobs_builtin_not_reaped
@@ -5,16 +5,19 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2503[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2503[0m
+[33m[your-program] [0m[0m[1] 2997[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2997[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 2997[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[2] 2506[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2506[0m
+[33m[your-program] [0m[0m[2] 3000[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 3000[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 3000[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54 &[0m
-[33m[your-program] [0m[0m[3] 2510[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2510[0m
+[33m[your-program] [0m[0m[3] 3004[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 3004[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 3004[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/apple-80"[0m
 [33m[your-program] [0m[0m$ jobs[0m

--- a/internal/test_helpers/fixtures/background_jobs_middleware_launch
+++ b/internal/test_helpers/fixtures/background_jobs_middleware_launch
@@ -3,8 +3,9 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_program.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2562[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2562[0m
+[33m[your-program] [0m[0m[1] 2413[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2413[0m
+[33m[tester::#AT7] [0m[92m✓ Expected executable path found for process with PID 2413[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/background_jobs_wrong_executable
+++ b/internal/test_helpers/fixtures/background_jobs_wrong_executable
@@ -1,0 +1,9 @@
+Debug = true
+
+[33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
+[33m[tester::#AT7] [0m[94mRunning ./your_program.sh[0m
+[33m[your-program] [0m[0m$ sleep 500 &[0m
+[33m[your-program] [0m[0m[1] 2161[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2161[0m
+[33m[tester::#AT7] [0m[91mExpected executable path for sleep to be "/bin/sleep", got "/usr/bin/python3.12"[0m
+[33m[tester::#AT7] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/bash/background_jobs/pass
+++ b/internal/test_helpers/fixtures/bash/background_jobs/pass
@@ -13,8 +13,9 @@ Debug = true
 [33m[tester::#AT7] [0m[94mRunning tests for Stage #AT7 (at7)[0m
 [33m[tester::#AT7] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2729[0m
-[33m[tester::#AT7] [0m[92m✓ Found process with PID 2729[0m
+[33m[your-program] [0m[0m[1] 2872[0m
+[33m[tester::#AT7] [0m[92m✓ Found process with PID 2872[0m
+[33m[tester::#AT7] [0m[92m✓ Expected executable path found for process with PID 2872[0m
 [33m[tester::#AT7] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#AT7] [0m[92mTest passed.[0m
@@ -24,8 +25,9 @@ Debug = true
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/apple-80[0m
 [33m[tester::#SI2] [setup] [0m[94mmkfifo /tmp/blueberry-54[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-80 &[0m
-[33m[your-program] [0m[0m[1] 2733[0m
-[33m[tester::#SI2] [0m[92m✓ Found process with PID 2733[0m
+[33m[your-program] [0m[0m[1] 2876[0m
+[33m[tester::#SI2] [0m[92m✓ Found process with PID 2876[0m
+[33m[tester::#SI2] [0m[92m✓ Expected executable path found for process with PID 2876[0m
 [33m[tester::#SI2] [0m[92m✓ Received next prompt[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-54[0m
 [33m[tester::#SI2] [setup] [0m[94mecho -e "Hello from FIFO #1" > "/tmp/apple-80"[0m
@@ -39,8 +41,9 @@ Debug = true
 [33m[tester::#JD6] [0m[94mRunning tests for Stage #JD6 (jd6)[0m
 [33m[tester::#JD6] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2738[0m
-[33m[tester::#JD6] [0m[92m✓ Found process with PID 2738[0m
+[33m[your-program] [0m[0m[1] 2885[0m
+[33m[tester::#JD6] [0m[92m✓ Found process with PID 2885[0m
+[33m[tester::#JD6] [0m[92m✓ Expected executable path found for process with PID 2885[0m
 [33m[tester::#JD6] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
@@ -51,23 +54,26 @@ Debug = true
 [33m[tester::#DK5] [0m[94mRunning tests for Stage #DK5 (dk5)[0m
 [33m[tester::#DK5] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2742[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2742[0m
+[33m[your-program] [0m[0m[1] 2889[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2889[0m
+[33m[tester::#DK5] [0m[92m✓ Expected executable path found for process with PID 2889[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 100 &[0m
 [33m[tester::#DK5] [0m[92m✓ 1 entry match the running job[0m
 [33m[your-program] [0m[0m$ sleep 200 &[0m
-[33m[your-program] [0m[0m[2] 2745[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2745[0m
+[33m[your-program] [0m[0m[2] 2892[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2892[0m
+[33m[tester::#DK5] [0m[92m✓ Expected executable path found for process with PID 2892[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m
 [33m[your-program] [0m[0m[2]+  Running                    sleep 200 &[0m
 [33m[tester::#DK5] [0m[92m✓ 2 entries match the running jobs[0m
 [33m[your-program] [0m[0m$ sleep 300 &[0m
-[33m[your-program] [0m[0m[3] 2749[0m
-[33m[tester::#DK5] [0m[92m✓ Found process with PID 2749[0m
+[33m[your-program] [0m[0m[3] 2896[0m
+[33m[tester::#DK5] [0m[92m✓ Found process with PID 2896[0m
+[33m[tester::#DK5] [0m[92m✓ Expected executable path found for process with PID 2896[0m
 [33m[tester::#DK5] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]   Running                    sleep 100 &[0m
@@ -81,8 +87,9 @@ Debug = true
 [33m[tester::#MA9] [0m[94mRunning ./your_shell.sh[0m
 [33m[tester::#MA9] [setup] [0m[94mmkfifo /tmp/apple-26[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-26 &[0m
-[33m[your-program] [0m[0m[1] 2755[0m
-[33m[tester::#MA9] [0m[92m✓ Found process with PID 2755[0m
+[33m[your-program] [0m[0m[1] 2902[0m
+[33m[tester::#MA9] [0m[92m✓ Found process with PID 2902[0m
+[33m[tester::#MA9] [0m[92m✓ Expected executable path found for process with PID 2902[0m
 [33m[tester::#MA9] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    cat /tmp/apple-26 &[0m
@@ -101,16 +108,19 @@ Debug = true
 [33m[tester::#RQ2] [setup] [0m[94mmkfifo /tmp/grape-92[0m
 [33m[tester::#RQ2] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2761[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2761[0m
+[33m[your-program] [0m[0m[1] 2907[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2907[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 2907[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/pineapple-90 &[0m
-[33m[your-program] [0m[0m[2] 2764[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2764[0m
+[33m[your-program] [0m[0m[2] 2910[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2910[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 2910[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/grape-92 &[0m
-[33m[your-program] [0m[0m[3] 2768[0m
-[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2768[0m
+[33m[your-program] [0m[0m[3] 2914[0m
+[33m[tester::#RQ2] [0m[92m✓ Found process with PID 2914[0m
+[33m[tester::#RQ2] [0m[92m✓ Expected executable path found for process with PID 2914[0m
 [33m[tester::#RQ2] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#RQ2] [setup] [0m[94mecho -ne "" > "/tmp/pineapple-90"[0m
 [33m[your-program] [0m[0m$ jobs[0m
@@ -133,12 +143,14 @@ Debug = true
 [33m[tester::#BV8] [setup] [0m[94mmkfifo /tmp/mango-48[0m
 [33m[tester::#BV8] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 500 &[0m
-[33m[your-program] [0m[0m[1] 2778[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2778[0m
+[33m[your-program] [0m[0m[1] 2920[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2920[0m
+[33m[tester::#BV8] [0m[92m✓ Expected executable path found for process with PID 2920[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/mango-48 &[0m
-[33m[your-program] [0m[0m[2] 2781[0m
-[33m[tester::#BV8] [0m[92m✓ Found process with PID 2781[0m
+[33m[your-program] [0m[0m[2] 2923[0m
+[33m[tester::#BV8] [0m[92m✓ Found process with PID 2923[0m
+[33m[tester::#BV8] [0m[92m✓ Expected executable path found for process with PID 2923[0m
 [33m[tester::#BV8] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 500 &[0m
@@ -159,8 +171,9 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/apple-55[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ cat /tmp/apple-55 &[0m
-[33m[your-program] [0m[0m[1] 2786[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2786[0m
+[33m[your-program] [0m[0m[1] 2929[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2929[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2929[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/apple-55"[0m
 [33m[your-program] [0m[0m$ echo blueberry[0m
@@ -173,8 +186,9 @@ Debug = true
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[tester::#FY4] [0m[92m✓ No jobs[0m
 [33m[your-program] [0m[0m$ sleep 10 &[0m
-[33m[your-program] [0m[0m[1] 2790[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2790[0m
+[33m[your-program] [0m[0m[1] 2932[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2932[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2932[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]+  Running                    sleep 10 &[0m
@@ -183,12 +197,14 @@ Debug = true
 [33m[tester::#FY4] [setup] [0m[94mmkfifo /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[94mRunning ./your_shell.sh[0m
 [33m[your-program] [0m[0m$ sleep 100 &[0m
-[33m[your-program] [0m[0m[1] 2794[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2794[0m
+[33m[your-program] [0m[0m[1] 2936[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2936[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2936[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ cat /tmp/blueberry-25 &[0m
-[33m[your-program] [0m[0m[2] 2797[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2797[0m
+[33m[your-program] [0m[0m[2] 2939[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2939[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2939[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[tester::#FY4] [setup] [0m[94mecho -ne "" > "/tmp/blueberry-25"[0m
 [33m[your-program] [0m[0m$ echo apple[0m
@@ -196,8 +212,9 @@ Debug = true
 [33m[your-program] [0m[0m[2]+  Done                       cat /tmp/blueberry-25[0m
 [33m[tester::#FY4] [0m[92m✓ Received output for echo followed by an entry for the reaped job[0m
 [33m[your-program] [0m[0m$ sleep 50 &[0m
-[33m[your-program] [0m[0m[2] 2801[0m
-[33m[tester::#FY4] [0m[92m✓ Found process with PID 2801[0m
+[33m[your-program] [0m[0m[2] 2943[0m
+[33m[tester::#FY4] [0m[92m✓ Found process with PID 2943[0m
+[33m[tester::#FY4] [0m[92m✓ Expected executable path found for process with PID 2943[0m
 [33m[tester::#FY4] [0m[92m✓ Output includes job number with PID[0m
 [33m[your-program] [0m[0m$ jobs[0m
 [33m[your-program] [0m[0m[1]-  Running                    sleep 100 &[0m

--- a/internal/test_helpers/scenarios/background_jobs_wrong_executable/codecrafters.yml
+++ b/internal/test_helpers/scenarios/background_jobs_wrong_executable/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/background_jobs_wrong_executable/main.py
+++ b/internal/test_helpers/scenarios/background_jobs_wrong_executable/main.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Minimal shell: base (oo8–ip1) + af3. Background jobs reparent through this Python so at7 path check always fails (not BusyBox/sh/sleep aliasing)."""
+
+import os
+import shlex
+import subprocess
+import sys
+
+PROMPT = "$ "
+BUILTINS = {"echo", "exit", "type", "jobs"}
+
+
+def find_in_path(name: str) -> str | None:
+    path = os.environ.get("PATH", "")
+    for part in path.split(os.pathsep):
+        if not part:
+            continue
+        full = os.path.join(part, name)
+        if os.path.isfile(full) and os.access(full, os.X_OK):
+            return full
+    return None
+
+
+def run_builtin(parts: list[str], last_exit: int) -> int | None:
+    cmd = parts[0]
+    if cmd == "exit":
+        if len(parts) > 1:
+            try:
+                code = int(parts[1])
+            except ValueError:
+                code = last_exit
+        else:
+            code = last_exit
+        sys.exit(code)
+    if cmd == "echo":
+        print(" ".join(parts[1:]) if len(parts) > 1 else "")
+        return 0
+    if cmd == "type":
+        if len(parts) < 2:
+            return 0
+        name = parts[1]
+        if name in BUILTINS:
+            print(f"{name} is a shell builtin")
+        else:
+            p = find_in_path(name)
+            print(f"{name} is {p}" if p else f"{name}: not found")
+        return 0
+    if cmd == "jobs":
+        return 0
+    return None
+
+
+def run_external(parts: list[str], background: bool) -> tuple[int | None, subprocess.Popen | None]:
+    name = parts[0]
+    path = find_in_path(name)
+    if path is None:
+        print(f"{name}: command not found", file=sys.stderr)
+        return 127, None
+    cmd_argv = [path] + parts[1:]
+    cmd_argv[0] = parts[0]
+    if background:
+        # Intentional: the PID we print is this interpreter (Popen child), not the real command.
+        script = (
+            "import os, subprocess as s; s.run("
+            + repr(parts)
+            + ", env=os.environ, stdin=s.DEVNULL, stdout=s.DEVNULL, stderr=s.DEVNULL)"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return None, proc
+    r = subprocess.run(cmd_argv, env=os.environ)
+    return (r.returncode if r.returncode is not None else 0), None
+
+
+def main() -> None:
+    last_exit = 0
+    job_no = 0
+    while True:
+        sys.stdout.write(PROMPT)
+        sys.stdout.flush()
+        line = sys.stdin.readline()
+        if not line:
+            break
+        raw = line.rstrip("\n\r")
+        bg = raw.rstrip().endswith("&")
+        line = raw.rstrip()[:-1].rstrip() if bg else raw.rstrip()
+        if not line:
+            continue
+        try:
+            parts = shlex.split(line)
+        except ValueError:
+            continue
+        if not parts:
+            continue
+        cmd = parts[0]
+        if cmd in BUILTINS:
+            ec = run_builtin(parts, last_exit)
+            if ec is not None:
+                last_exit = ec
+            continue
+        path = find_in_path(cmd)
+        if path is None:
+            print(f"{cmd}: command not found", file=sys.stderr)
+            last_exit = 127
+            continue
+        if bg:
+            _, proc = run_external(parts, True)
+            job_no += 1
+            print(f"[{job_no}] {proc.pid}")
+            sys.stdout.flush()
+        else:
+            code, _ = run_external(parts, False)
+            last_exit = code if code is not None else 0
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/background_jobs_wrong_executable/your_program.sh
+++ b/internal/test_helpers/scenarios/background_jobs_wrong_executable/your_program.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# This buggy implementation of shell will launch an incorrect executable in background
+exec python3 $(dirname "$0")/main.py "$@"

--- a/internal/utils/utils_sys.go
+++ b/internal/utils/utils_sys.go
@@ -7,8 +7,13 @@ import (
 	"github.com/codecrafters-io/tester-utils/executable"
 )
 
-func MustGetExecutablePathForCommand(command string) string {
-	absPath, err := executable.ResolveAbsolutePath(command)
+// MustGetExecutablePathAndResolvedSymlinkForCommand returns the absolute path for the command's executable
+// followed by the resolved path of the symlink if the absolute path is a symlink
+// For example, For 'sleep' if the absolute path is "/bin/sleep" which is a symbolic link
+// to "/bin/busybox", it returns ("/bin/sleep", "/bin/busybox")
+// For paths which are not symlinks, same value is returned twice
+func MustGetExecutablePathAndResolvedSymlinkForCommand(command string) (string, string) {
+	absolutePath, err := executable.ResolveAbsolutePath(command)
 	if err != nil {
 		panic(fmt.Sprintf(
 			"Codecrafters Internal Error - Failed to resolve absolute path for command %s: %s",
@@ -18,14 +23,14 @@ func MustGetExecutablePathForCommand(command string) string {
 	}
 
 	// The absolute path could be a symlink, so that must be resolved
-	resolvedAbsolutePath, err := filepath.EvalSymlinks(absPath)
+	resolvedAbsolutePath, err := filepath.EvalSymlinks(absolutePath)
 	if err != nil {
 		panic(fmt.Sprintf(
 			"Codecrafters Internal Error - Failed to resolve symlink for path %s: %s",
-			absPath,
+			absolutePath,
 			err,
 		))
 	}
 
-	return resolvedAbsolutePath
+	return absolutePath, resolvedAbsolutePath
 }

--- a/internal/utils/utils_sys.go
+++ b/internal/utils/utils_sys.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/codecrafters-io/tester-utils/executable"
+)
+
+func MustGetExecutablePathForCommand(command string) string {
+	absPath, err := executable.ResolveAbsolutePath(command)
+	if err != nil {
+		panic(fmt.Sprintf(
+			"Codecrafters Internal Error - Failed to resolve absolute path for command %s: %s",
+			command,
+			err,
+		))
+	}
+
+	// The absolute path could be a symlink, so that must be resolved
+	resolvedAbsolutePath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		panic(fmt.Sprintf(
+			"Codecrafters Internal Error - Failed to resolve symlink for path %s: %s",
+			absPath,
+			err,
+		))
+	}
+
+	return resolvedAbsolutePath
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds OS-level process inspection to background job tests, which could be platform-dependent (PATH/symlinks/process APIs) and affect stage pass/fail behavior.
> 
> **Overview**
> **Background job validation is tightened** by asserting that the PID printed for `cmd &` actually corresponds to a process executing the expected binary (allowing for symlink-resolved paths).
> 
> This introduces a new helper `utils.MustGetExecutablePathAndResolvedSymlinkForCommand`, updates output normalization/fixtures to account for the new success message, and adds a new failing scenario (`background_jobs_wrong_executable_path`) that demonstrates a shell printing the PID of an intermediate launcher instead of the real command. Dependency `tester-utils` is bumped to `v0.4.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f5b9cac0289e13d2b4e052abe3c8eb736b52bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->