### PR TITLE
Parameter Expansion (1/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,18 @@ define _HISTORY_PERSISTENCE_STAGES
 ]
 endef
 
+define _PARAMETER_EXPANSION_STAGES
+[ \
+	{"slug":"ji0","tester_log_prefix":"tester::#ji0","title":"Stage#1: The declare builtin"}, \
+	{"slug":"oa2","tester_log_prefix":"tester::#oa2","title":"Stage#2: Printing non-existing variables"}, \
+	{"slug":"kv5","tester_log_prefix":"tester::#kv5","title":"Stage#3: Storing shell variables"}, \
+	{"slug":"db8","tester_log_prefix":"tester::#db8","title":"Stage#4: Validating shell variable names"}, \
+	{"slug":"ge9","tester_log_prefix":"tester::#ge9","title":"Stage#5: Expanding variables"}, \
+	{"slug":"br2","tester_log_prefix":"tester::#br2","title":"Stage#6: Expansion with braces"}, \
+	{"slug":"my0","tester_log_prefix":"tester::#my0","title":"Stage#7: Expansion when a name is unset"} \
+]
+endef
+
 # Use eval to properly escape the stage arrays
 define quote_strings
 	$(shell echo '$(1)' | sed 's/"/\\"/g')
@@ -275,6 +287,7 @@ HISTORY_STAGES = $(call quote_strings,$(_HISTORY_STAGES))
 HISTORY_STAGES_ZSH = $(call quote_strings,$(_HISTORY_STAGES_ZSH))
 HISTORY_STAGES_ASH = $(call quote_strings,$(_HISTORY_STAGES_ASH))
 HISTORY_PERSISTENCE_STAGES = $(call quote_strings,$(_HISTORY_PERSISTENCE_STAGES))
+PARAMETER_EXPANSION_STAGES = $(call quote_strings,$(_PARAMETER_EXPANSION_STAGES))
 
 test_base_w_ash: build
 	$(call run_test,$(BASE_STAGES),ash)
@@ -363,6 +376,12 @@ test_history_w_ash: build
 test_history_persistence_w_bash: build
 	$(call run_test,$(HISTORY_PERSISTENCE_STAGES),bash)
 
+test_parameter_expansion_w_bash: build
+	$(call run_test,$(PARAMETER_EXPANSION_STAGES),bash)
+
+test_parameter_expansion_w_zsh: build
+	$(call run_test,$(PARAMETER_EXPANSION_STAGES),zsh)
+
 test_ash:
 	make test_base_w_ash
 	make test_nav_w_ash
@@ -383,6 +402,7 @@ test_bash:
 	make test_background_jobs_w_bash
 	make test_history_w_bash
 	make test_history_persistence_w_bash
+	make test_parameter_expansion_w_bash
 
 # Doesn't support completions, history
 test_dash:
@@ -400,6 +420,7 @@ test_zsh:
 	make test_completions_w_zsh
 	make test_filename_completion_w_zsh
 	make test_history_w_zsh
+	make test_parameter_expansion_w_zsh
 
 # Clone the repo in `debug` directory
 test_debug: build

--- a/internal/stage_pex1.go
+++ b/internal/stage_pex1.go
@@ -1,7 +1,30 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX1(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	typeOfTestCase := test_cases.TypeOfCommandTestCase{
+		Command: "declare",
+		// For ZSH, it is a reserved word
+		IsCommandAlsoAReservedWord: true,
+	}
+
+	if err := typeOfTestCase.RunForBuiltin(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex1.go
+++ b/internal/stage_pex1.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX1(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex2.go
+++ b/internal/stage_pex2.go
@@ -1,7 +1,33 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"strconv"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX2(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	missingVariable := "missing_variable_" + strconv.Itoa(random.RandomInt(1, 100))
+
+	testCase := test_cases.DeclarePrintErrorTestCase{
+		Variable: missingVariable,
+	}
+
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex2.go
+++ b/internal/stage_pex2.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX2(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex3.go
+++ b/internal/stage_pex3.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX3(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex3.go
+++ b/internal/stage_pex3.go
@@ -1,7 +1,49 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX3(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	words := random.RandomWords(2)
+	variableName := words[0]
+	variableValue := words[1]
+
+	assignTestCase := test_cases.DeclareAssignmentTestCase{
+		Variable: variableName,
+		Value:    variableValue,
+	}
+	if err := assignTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	printTestCase := test_cases.DeclarePrintTestCase{
+		Variable: variableName,
+		Value:    variableValue,
+	}
+	if err := printTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	missingVariable := "missing_" + random.RandomWords(1)[0]
+	printErrorTestCase := test_cases.DeclarePrintErrorTestCase{
+		Variable: missingVariable,
+	}
+	if err := printErrorTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex3.go
+++ b/internal/stage_pex3.go
@@ -17,31 +17,34 @@ func testPEX3(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	words := random.RandomWords(2)
+	words := random.RandomWords(3)
 	variableName := words[0]
 	variableValue := words[1]
+	newVariableValue := words[2]
 
-	assignTestCase := test_cases.DeclareAssignmentTestCase{
-		Variable: variableName,
-		Value:    variableValue,
-	}
+	assignTestCase := test_cases.DeclareAssignmentTestCase{Variable: variableName, Value: variableValue}
 	if err := assignTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	printTestCase := test_cases.DeclarePrintTestCase{
-		Variable: variableName,
-		Value:    variableValue,
-	}
+	printTestCase := test_cases.DeclarePrintTestCase{Variable: variableName, Value: variableValue}
 	if err := printTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
 	missingVariable := "missing_" + random.RandomWords(1)[0]
-	printErrorTestCase := test_cases.DeclarePrintErrorTestCase{
-		Variable: missingVariable,
-	}
+	printErrorTestCase := test_cases.DeclarePrintErrorTestCase{Variable: missingVariable}
 	if err := printErrorTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	reassignTestCase := test_cases.DeclareAssignmentTestCase{Variable: variableName, Value: newVariableValue}
+	if err := reassignTestCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	printNewValueTestCase := test_cases.DeclarePrintTestCase{Variable: variableName, Value: newVariableValue}
+	if err := printNewValueTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_pex4.go
+++ b/internal/stage_pex4.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX4(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex4.go
+++ b/internal/stage_pex4.go
@@ -1,7 +1,47 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX4(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	words := random.RandomWords(4)
+
+	// Valid assignment: underscore-prefixed name
+	validVariable := "_" + words[0]
+	validVariableValue := words[1]
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: validVariable, Value: validVariableValue}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Invalid assignment: name starting with a digit
+	invalidVariable := fmt.Sprintf("%d%s", random.RandomInt(2, 9), words[2])
+	invalidVariableValue := words[3]
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: invalidVariable, Value: invalidVariableValue}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	if err := (test_cases.DeclarePrintTestCase{Variable: validVariable, Value: validVariableValue}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	if err := (test_cases.DeclarePrintErrorTestCase{Variable: invalidVariable}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -67,7 +67,7 @@ func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -1,7 +1,79 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	// Declare two variables with valid names and random values
+	words := random.RandomWords(4)
+	integerSuffixes := random.RandomInts(1, 10, 2)
+	variableName1 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[0][:1])+words[0][1:],
+		integerSuffixes[0],
+	)
+	variableName2 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[1][:1])+words[1][1:],
+		integerSuffixes[1],
+	)
+	varValue1 := words[2]
+	varValue2 := words[3]
+
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: varValue1}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: varValue2}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Run the executable with $VAR1 $VAR2 — shell must expand before passing args
+	command := fmt.Sprintf("%s $%s $%s", executableName, variableName1, variableName2)
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		fmt.Sprintf("Arg #1: %s", varValue1),
+		fmt.Sprintf("Arg #2: %s", varValue2),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -76,7 +76,7 @@ func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -1,7 +1,88 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	// Declare two variables with valid names and random values
+	words := random.RandomWords(6)
+	integerSuffixes := random.RandomInts(1, 10, 2)
+	variableName1 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[0][:1])+words[0][1:],
+		integerSuffixes[0],
+	)
+	variableName2 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[1][:1])+words[1][1:],
+		integerSuffixes[1],
+	)
+	variableValue1 := words[2]
+	variableValue2 := words[3]
+	literalPrefix := words[4]
+	literalSuffix := words[5]
+
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: variableValue1}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: variableValue2}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Run the executable with ${VAR1} embedded between random literal prefix/suffix,
+	// and ${VAR2} as a standalone brace-expansion argument.
+	argument1 := fmt.Sprintf("%s_${%s}_%s", literalPrefix, variableName1, literalSuffix)
+	argument2 := fmt.Sprintf("${%s}", variableName2)
+	command := fmt.Sprintf("%s %s %s", executableName, argument1, argument2)
+
+	expectedArgument1 := fmt.Sprintf("%s_%s_%s", literalPrefix, variableValue1, literalSuffix)
+	expectedArgument2 := variableValue2
+
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		fmt.Sprintf("Arg #1: %s", expectedArgument1),
+		fmt.Sprintf("Arg #2: %s", expectedArgument2),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/codecrafters-io/tester-utils/test_case_harness"
+
+func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
+	return nil
+}

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -55,7 +54,7 @@ func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -1,7 +1,67 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	existingValue := random.RandomWords(1)[0]
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: "existing", Value: existingValue}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	integerSuffixes := random.RandomInts(1, 99, 2)
+	command := fmt.Sprintf(
+		"%s ${missing_var_%d}_suffix ${existing} ${missing_var_%d}",
+		executableName,
+		integerSuffixes[0],
+		integerSuffixes[1],
+	)
+
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		"Arg #1: _suffix",
+		fmt.Sprintf("Arg #2: %s", existingValue),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -216,6 +216,13 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/bash/history_persistence/pass",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"parameter_expansion_pass_bash": {
+			StageSlugs:          []string{"ji0", "oa2", "kv5", "db8", "ge9", "br2", "my0"},
+			CodePath:            "./test_helpers/bash",
+			ExpectedExitCode:    0,
+			StdoutFixturePath:   "./test_helpers/fixtures/bash/parameter_expansion/pass",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"base_pass_ash": {
 			UntilStageSlug:      "ip1",
 			CodePath:            "./test_helpers/ash",

--- a/internal/test_cases/declare_assignment_test_case.go
+++ b/internal/test_cases/declare_assignment_test_case.go
@@ -1,0 +1,48 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+// DeclareAssignmentTestCase tests `VAR=value` style assignment via declare.
+// If the variable name is valid, no output is expected.
+// If invalid, the shell must print an error.
+type DeclareAssignmentTestCase struct {
+	Variable string
+	Value    string
+}
+
+func (t DeclareAssignmentTestCase) IsValidAssignment() bool {
+	return isValidIdentifier(t.Variable)
+}
+
+func (t DeclareAssignmentTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	assignment := fmt.Sprintf("%s=%s", t.Variable, t.Value)
+
+	if t.IsValidAssignment() {
+		testCase := CommandWithNoResponseTestCase{
+			Command:        fmt.Sprintf("declare %s", assignment),
+			SuccessMessage: "✓ Received expected response",
+		}
+		return testCase.Run(asserter, shell, logger, false)
+	}
+
+	expectedOutput := fmt.Sprintf("declare: `%s': not a valid identifier", assignment)
+	testCase := CommandResponseTestCase{
+		Command:        fmt.Sprintf("declare %s", assignment),
+		ExpectedOutput: expectedOutput,
+		FallbackPatterns: []*regexp.Regexp{
+			// bash prefixes with "bash: "
+			regexp.MustCompile(fmt.Sprintf("^bash: declare: `%s': not a valid identifier$", regexp.QuoteMeta(assignment))),
+			// zsh uses "not an identifier" phrasing
+			regexp.MustCompile(fmt.Sprintf(`^declare: not an identifier: %s$`, regexp.QuoteMeta(t.Variable))),
+		},
+		SuccessMessage: "✓ Received expected response",
+	}
+	return testCase.Run(asserter, shell, logger)
+}

--- a/internal/test_cases/declare_print_error_test_case.go
+++ b/internal/test_cases/declare_print_error_test_case.go
@@ -1,0 +1,36 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+// DeclarePrintErrorTestCase tests `declare -p VAR` when the variable does not exist.
+// Expected output: declare: VAR: not found
+type DeclarePrintErrorTestCase struct {
+	Variable string
+}
+
+func (t DeclarePrintErrorTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	fallbackPatterns := []*regexp.Regexp{
+		regexp.MustCompile(fmt.Sprintf(`^bash: declare: %s: not found$`, regexp.QuoteMeta(t.Variable))),
+		regexp.MustCompile(fmt.Sprintf(`^declare: no such variable: %s$`, regexp.QuoteMeta(t.Variable))),
+	}
+
+	if !isValidIdentifier(t.Variable) {
+		// zsh rejects invalid identifiers passed to -p
+		fallbackPatterns = append(fallbackPatterns, regexp.MustCompile(fmt.Sprintf(`^declare: bad argument to -p: %s$`, regexp.QuoteMeta(t.Variable))))
+	}
+
+	testCase := CommandResponseTestCase{
+		Command:          fmt.Sprintf("declare -p %s", t.Variable),
+		ExpectedOutput:   fmt.Sprintf("declare: %s: not found", t.Variable),
+		FallbackPatterns: fallbackPatterns,
+		SuccessMessage:   "✓ Received expected response",
+	}
+	return testCase.Run(asserter, shell, logger)
+}

--- a/internal/test_cases/declare_print_test_case.go
+++ b/internal/test_cases/declare_print_test_case.go
@@ -1,0 +1,30 @@
+package test_cases
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+// DeclarePrintTestCase tests `declare -p VAR` when the variable exists.
+// Expected output format: declare -- VAR="value"
+type DeclarePrintTestCase struct {
+	Variable string
+	Value    string
+}
+
+func (t DeclarePrintTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	testCase := CommandResponseTestCase{
+		Command:        fmt.Sprintf("declare -p %s", t.Variable),
+		ExpectedOutput: fmt.Sprintf(`declare -- %s="%s"`, t.Variable, t.Value),
+		FallbackPatterns: []*regexp.Regexp{
+			// zsh uses `typeset VAR=value` format
+			regexp.MustCompile(fmt.Sprintf(`^typeset %s=%s$`, regexp.QuoteMeta(t.Variable), regexp.QuoteMeta(t.Value))),
+		},
+		SuccessMessage: "✓ Received expected response",
+	}
+	return testCase.Run(asserter, shell, logger)
+}

--- a/internal/test_cases/type_of_command_test_case.go
+++ b/internal/test_cases/type_of_command_test_case.go
@@ -11,14 +11,20 @@ import (
 )
 
 type TypeOfCommandTestCase struct {
-	Command string
+	Command                    string
+	IsCommandAlsoAReservedWord bool
 }
 
 func (t *TypeOfCommandTestCase) RunForBuiltin(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+	fallbackPatterns := []*regexp.Regexp{regexp.MustCompile(fmt.Sprintf(`^%s is a( special)? shell builtin$`, t.Command))}
+	if t.IsCommandAlsoAReservedWord {
+		fallbackPatterns = append(fallbackPatterns, regexp.MustCompile(fmt.Sprintf(`^%s is a reserved word$`, t.Command)))
+	}
+
 	testCase := CommandResponseTestCase{
 		Command:          fmt.Sprintf("type %s", t.Command),
 		ExpectedOutput:   fmt.Sprintf(`%s is a shell builtin`, t.Command),
-		FallbackPatterns: []*regexp.Regexp{regexp.MustCompile(fmt.Sprintf(`^%s is a( special)? shell builtin$`, t.Command))},
+		FallbackPatterns: fallbackPatterns,
 		SuccessMessage:   "✓ Received expected response",
 	}
 

--- a/internal/test_cases/utils.go
+++ b/internal/test_cases/utils.go
@@ -1,0 +1,23 @@
+package test_cases
+
+import "unicode"
+
+// isValidIdentifier returns true if name starts with a letter or underscore
+// followed only by letters, digits, or underscores.
+func isValidIdentifier(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+		} else {
+			if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -121,6 +121,11 @@ extensions:
 
       History persistence allows you to save and load previously entered commands to and from a file.
 
+  - slug: "parameter-expansion"
+    name: "Parameter Expansion"
+    description_markdown: |
+      In this challenge extension, you'll add `declare` (including valid names) and `$VAR` / `${VAR}` parameter expansion (including when a name is unset).
+
 stages:
   - slug: "oo8"
     name: "Print a prompt"
@@ -1981,3 +1986,52 @@ stages:
 
     marketing_md: |-
       In this stage, you'll implement support for appending the in-memory history to the history file when exiting.
+
+  - slug: "ji0"
+    primary_extension_slug: "parameter-expansion"
+    name: "The declare builtin"
+    difficulty: easy
+    marketing_md: |-
+      In this stage, you'll register the `declare` builtin.
+
+  - slug: "oa2"
+    primary_extension_slug: "parameter-expansion"
+    name: "Printing non-existing variables"
+    difficulty: easy
+    marketing_md: |-
+      In this stage, you'll implement the `-p` flag of the declare builtin when the requested variable does not exist.
+
+  - slug: "kv5"
+    primary_extension_slug: "parameter-expansion"
+    name: "Storing shell variables"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll add support for storing and displaying shell variables.
+
+  - slug: "db8"
+    primary_extension_slug: "parameter-expansion"
+    name: "Validating shell variable names"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll add support for validation for shell variable names.
+
+  - slug: "ge9"
+    primary_extension_slug: "parameter-expansion"
+    name: "Expanding variables"
+    difficulty: hard
+    marketing_md: |-
+      In this stage, you'll add support for parameter expansion using the `$VAR` form.
+
+  - slug: "br2"
+    primary_extension_slug: "parameter-expansion"
+    name: "Expansion with braces"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll add support for parameter expansion using the `${VAR}` form.
+
+  - slug: "my0"
+    primary_extension_slug: "parameter-expansion"
+    name: "Expansion when a name is unset"
+    difficulty: medium
+    marketing_md: |-
+      In this stage, you'll add support for expanding the variable name when it is not set.

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -1,15 +1,48 @@
 Debug = true
 
 [33m[tester::#JI0] [0m[94mRunning tests for Stage #JI0 (ji0)[0m
+[33m[tester::#JI0] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ type declare[0m
+[33m[your-program] [0m[0mdeclare is a shell builtin[0m
+[33m[tester::#JI0] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#JI0] [0m[92mTest passed.[0m
 
 [33m[tester::#OA2] [0m[94mRunning tests for Stage #OA2 (oa2)[0m
+[33m[tester::#OA2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare -p missing_variable_28[0m
+[33m[your-program] [0m[0mbash: declare: missing_variable_28: not found[0m
+[33m[tester::#OA2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#OA2] [0m[92mTest passed.[0m
 
 [33m[tester::#KV5] [0m[94mRunning tests for Stage #KV5 (kv5)[0m
+[33m[tester::#KV5] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare orange=pear[0m
+[33m[tester::#KV5] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare -p orange[0m
+[33m[your-program] [0m[0mdeclare -- orange="pear"[0m
+[33m[tester::#KV5] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare -p missing_pineapple[0m
+[33m[your-program] [0m[0mbash: declare: missing_pineapple: not found[0m
+[33m[tester::#KV5] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#KV5] [0m[92mTest passed.[0m
 
 [33m[tester::#DB8] [0m[94mRunning tests for Stage #DB8 (db8)[0m
+[33m[tester::#DB8] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare _pineapple=orange[0m
+[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare 5raspberry=apple[0m
+[33m[your-program] [0m[0mbash: declare: `5raspberry=apple': not a valid identifier[0m
+[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare -p _pineapple[0m
+[33m[your-program] [0m[0mdeclare -- _pineapple="orange"[0m
+[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare -p 5raspberry[0m
+[33m[your-program] [0m[0mbash: declare: 5raspberry: not found[0m
+[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#DB8] [0m[92mTest passed.[0m
 
 [33m[tester::#GE9] [0m[94mRunning tests for Stage #GE9 (ge9)[0m

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -1,0 +1,22 @@
+Debug = true
+
+[33m[tester::#JI0] [0m[94mRunning tests for Stage #JI0 (ji0)[0m
+[33m[tester::#JI0] [0m[92mTest passed.[0m
+
+[33m[tester::#OA2] [0m[94mRunning tests for Stage #OA2 (oa2)[0m
+[33m[tester::#OA2] [0m[92mTest passed.[0m
+
+[33m[tester::#KV5] [0m[94mRunning tests for Stage #KV5 (kv5)[0m
+[33m[tester::#KV5] [0m[92mTest passed.[0m
+
+[33m[tester::#DB8] [0m[94mRunning tests for Stage #DB8 (db8)[0m
+[33m[tester::#DB8] [0m[92mTest passed.[0m
+
+[33m[tester::#GE9] [0m[94mRunning tests for Stage #GE9 (ge9)[0m
+[33m[tester::#GE9] [0m[92mTest passed.[0m
+
+[33m[tester::#BR2] [0m[94mRunning tests for Stage #BR2 (br2)[0m
+[33m[tester::#BR2] [0m[92mTest passed.[0m
+
+[33m[tester::#MY0] [0m[94mRunning tests for Stage #MY0 (my0)[0m
+[33m[tester::#MY0] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -46,10 +46,56 @@ Debug = true
 [33m[tester::#DB8] [0m[92mTest passed.[0m
 
 [33m[tester::#GE9] [0m[94mRunning tests for Stage #GE9 (ge9)[0m
+[33m[tester::#GE9] [setup] [0m[94mexport PATH=/tmp/pig:$PATH[0m
+[33m[tester::#GE9] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#GE9] [setup] [0m[94m- custom_exe_6864[0m
+[33m[tester::#GE9] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare Grape_1=strawberry[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare Pear_2=banana[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_6864 $Grape_1 $Pear_2[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_6864[0m
+[33m[your-program] [0m[0mArg #1: strawberry[0m
+[33m[your-program] [0m[0mArg #2: banana[0m
+[33m[your-program] [0m[0mProgram Signature: 2314588360[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#GE9] [0m[92mTest passed.[0m
 
 [33m[tester::#BR2] [0m[94mRunning tests for Stage #BR2 (br2)[0m
+[33m[tester::#BR2] [setup] [0m[94mexport PATH=/tmp/owl:$PATH[0m
+[33m[tester::#BR2] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#BR2] [setup] [0m[94m- custom_exe_5355[0m
+[33m[tester::#BR2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare Raspberry_2=mango[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare Pineapple_9=pear[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_5355 grape_${Raspberry_2}_banana ${Pineapple_9}[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_5355[0m
+[33m[your-program] [0m[0mArg #1: grape_mango_banana[0m
+[33m[your-program] [0m[0mArg #2: pear[0m
+[33m[your-program] [0m[0mProgram Signature: 4420233970[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#BR2] [0m[92mTest passed.[0m
 
 [33m[tester::#MY0] [0m[94mRunning tests for Stage #MY0 (my0)[0m
+[33m[tester::#MY0] [setup] [0m[94mexport PATH=/tmp/rat:$PATH[0m
+[33m[tester::#MY0] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#MY0] [setup] [0m[94m- custom_exe_8866[0m
+[33m[tester::#MY0] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare existing=mango[0m
+[33m[tester::#MY0] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_8866 ${missing_var_8}_suffix ${existing} ${missing_var_46}[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_8866[0m
+[33m[your-program] [0m[0mArg #1: _suffix[0m
+[33m[your-program] [0m[0mArg #2: mango[0m
+[33m[your-program] [0m[0mProgram Signature: 7313273050[0m
+[33m[tester::#MY0] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#MY0] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -26,6 +26,11 @@ Debug = true
 [33m[your-program] [0m[0m$ declare -p missing_pineapple[0m
 [33m[your-program] [0m[0mbash: declare: missing_pineapple: not found[0m
 [33m[tester::#KV5] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare orange=grape[0m
+[33m[tester::#KV5] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare -p orange[0m
+[33m[your-program] [0m[0mdeclare -- orange="grape"[0m
+[33m[tester::#KV5] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#KV5] [0m[92mTest passed.[0m
 

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -366,5 +366,41 @@ var testerDefinition = tester_definition.TesterDefinition{
 			TestFunc: testHP6,
 			Timeout:  15 * time.Second,
 		},
+		// Parameter Expansion
+		{
+			Slug:     "ji0",
+			TestFunc: testPEX1,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "oa2",
+			TestFunc: testPEX2,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "kv5",
+			TestFunc: testPEX3,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "db8",
+			TestFunc: testPEX4,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "ge9",
+			TestFunc: testPEX5,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "br2",
+			TestFunc: testPEX6,
+			Timeout:  15 * time.Second,
+		},
+		{
+			Slug:     "my0",
+			TestFunc: testPEX7,
+			Timeout:  15 * time.Second,
+		},
 	},
 }


### PR DESCRIPTION
Stages 5-7 will be added in new PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive tester/content changes (new stages, fixtures, and test helpers) with minimal impact on existing execution paths, aside from slight broadening of `TypeOfCommandTestCase` output matching.
> 
> **Overview**
> Introduces a new **Parameter Expansion** extension with stages `ji0`–`my0`, wiring them into the tester (`tester_definition.go`), local stage test suite (`stages_test.go`), and developer Makefile targets for bash/zsh runs.
> 
> Adds new stage implementations (`stage_pex1`–`stage_pex7`) plus dedicated test-case helpers for `declare` assignment/printing/error handling and identifier validation, along with a recorded bash fixture to validate expected outputs and cross-shell output variants (notably zsh vs bash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e4ea469f7690a01b12d86321d9ef5eddefe1c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->