### PR TITLE
Reduce Redirection's dependence on Quoting

### DIFF
--- a/internal/stage_r1.go
+++ b/internal/stage_r1.go
@@ -83,7 +83,7 @@ func testR1(stageHarness *test_case_harness.TestCaseHarness) error {
 	// echo "Hello Ryan" 1> tmp.md; cat tmp.md
 
 	message := "Hello " + getRandomName()
-	command3 := fmt.Sprintf("echo '%s' 1> %s", message, outputFilePath2)
+	command3 := fmt.Sprintf("echo %s 1> %s", message, outputFilePath2)
 	command4 := fmt.Sprintf("%s %s", CUSTOM_CAT_COMMAND, outputFilePath2)
 
 	err = test_cases.CommandWithNoResponseTestCase{

--- a/internal/stage_r2.go
+++ b/internal/stage_r2.go
@@ -80,7 +80,7 @@ func testR2(stageHarness *test_case_harness.TestCaseHarness) error {
 	// echo 'File not found' 2> tmp.md; cat tmp.md
 
 	message := fmt.Sprintf("%s file cannot be found", getRandomName())
-	command3 := fmt.Sprintf("echo %s 2> %s", fmt.Sprintf("'%s'", message), outputFilePath2)
+	command3 := fmt.Sprintf("echo %s 2> %s", message, outputFilePath2)
 
 	responseTestCase = test_cases.CommandResponseTestCase{
 		Command:          command3,

--- a/internal/stage_r3.go
+++ b/internal/stage_r3.go
@@ -85,8 +85,8 @@ func testR3(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	message1 := "Hello " + getRandomName()
 	message2 := "Hello " + getRandomName()
-	command4 := fmt.Sprintf("echo '%s' 1>> %s", message1, outputFilePath2)
-	command5 := fmt.Sprintf("echo '%s' 1>> %s", message2, outputFilePath2)
+	command4 := fmt.Sprintf("echo %s 1>> %s", message1, outputFilePath2)
+	command5 := fmt.Sprintf("echo %s 1>> %s", message2, outputFilePath2)
 	command6 := fmt.Sprintf("%s %s", CUSTOM_CAT_COMMAND, outputFilePath2)
 
 	err = test_cases.CommandWithNoResponseTestCase{

--- a/internal/stage_r3.go
+++ b/internal/stage_r3.go
@@ -115,7 +115,7 @@ func testR3(stageHarness *test_case_harness.TestCaseHarness) error {
 	// Test3:
 	// echo "List of files: " > tmp.md; ls -1 foo >> tmp.md; cat tmp.md
 
-	command7 := fmt.Sprintf(`echo "List of files: " > %s`, outputFilePath3)
+	command7 := fmt.Sprintf(`echo List of files: > %s`, outputFilePath3)
 	command8 := fmt.Sprintf("%s -1 %s >> %s", CUSTOM_LS_COMMAND, lsDir, outputFilePath3)
 	command9 := fmt.Sprintf("%s %s", CUSTOM_CAT_COMMAND, outputFilePath3)
 

--- a/internal/stage_r4.go
+++ b/internal/stage_r4.go
@@ -97,7 +97,7 @@ func testR4(stageHarness *test_case_harness.TestCaseHarness) error {
 	// cat tmp.md
 
 	message := fmt.Sprintf("%s says Error", getRandomName())
-	command4 := fmt.Sprintf(`echo "%s" 2>> %s`, message, outputFilePath3)
+	command4 := fmt.Sprintf(`echo %s 2>> %s`, message, outputFilePath3)
 	command5 := fmt.Sprintf(`%s %s 2>> %s`, CUSTOM_CAT_COMMAND, "nonexistent", outputFilePath3)
 	command6 := fmt.Sprintf("%s -1 %s 2>> %s", CUSTOM_LS_COMMAND, "nonexistent", outputFilePath3)
 	command7 := fmt.Sprintf("%s %s", CUSTOM_CAT_COMMAND, outputFilePath3)

--- a/internal/test_helpers/fixtures/ash/redirection/pass
+++ b/internal/test_helpers/fixtures/ash/redirection/pass
@@ -86,7 +86,7 @@ Debug = true
 [33m[your-program] [0m[0m$ cat /tmp/rat/owl.md[0m
 [33m[your-program] [0m[0mls: nonexistent: No such file or directory[0m
 [33m[tester::#UN3] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo "David says Error" 2>> /tmp/rat/pig.md[0m
+[33m[your-program] [0m[0m$ echo David says Error 2>> /tmp/rat/pig.md[0m
 [33m[your-program] [0m[0mDavid says Error[0m
 [33m[tester::#UN3] [0m[92m✓ Received redirected file content[0m
 [33m[your-program] [0m[0m$ cat nonexistent 2>> /tmp/rat/pig.md[0m

--- a/internal/test_helpers/fixtures/ash/redirection/pass
+++ b/internal/test_helpers/fixtures/ash/redirection/pass
@@ -64,7 +64,7 @@ Debug = true
 [33m[your-program] [0m[0mHello Maria[0m
 [33m[your-program] [0m[0mHello David[0m
 [33m[tester::#EL9] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo "List of files: " > /tmp/rat/fox.md[0m
+[33m[your-program] [0m[0m$ echo List of files: > /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0m$ ls -1 /tmp/fox >> /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0mList of files:[0m

--- a/internal/test_helpers/fixtures/ash/redirection/pass
+++ b/internal/test_helpers/fixtures/ash/redirection/pass
@@ -12,7 +12,7 @@ Debug = true
 [33m[your-program] [0m[0mpear[0m
 [33m[your-program] [0m[0mpineapple[0m
 [33m[tester::#JV1] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo 'Hello Alice' 1> /tmp/rat/cow.md[0m
+[33m[your-program] [0m[0m$ echo Hello Alice 1> /tmp/rat/cow.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/cow.md[0m
 [33m[your-program] [0m[0mHello Alice[0m
 [33m[tester::#JV1] [0m[92m✓ Received redirected file content[0m
@@ -58,8 +58,8 @@ Debug = true
 [33m[your-program] [0m[0mpineapple[0m
 [33m[your-program] [0m[0mstrawberry[0m
 [33m[tester::#EL9] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo 'Hello Maria' 1>> /tmp/rat/dog.md[0m
-[33m[your-program] [0m[0m$ echo 'Hello David' 1>> /tmp/rat/dog.md[0m
+[33m[your-program] [0m[0m$ echo Hello Maria 1>> /tmp/rat/dog.md[0m
+[33m[your-program] [0m[0m$ echo Hello David 1>> /tmp/rat/dog.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/dog.md[0m
 [33m[your-program] [0m[0mHello Maria[0m
 [33m[your-program] [0m[0mHello David[0m

--- a/internal/test_helpers/fixtures/ash/redirection/pass
+++ b/internal/test_helpers/fixtures/ash/redirection/pass
@@ -33,7 +33,7 @@ Debug = true
 [33m[your-program] [0m[0m$ cat /tmp/fox/dog.md[0m
 [33m[your-program] [0m[0mls: nonexistent: No such file or directory[0m
 [33m[tester::#VZ4] [0m[92m✓ Received redirected error message[0m
-[33m[your-program] [0m[0m$ echo 'Alice file cannot be found' 2> /tmp/fox/fox.md[0m
+[33m[your-program] [0m[0m$ echo Alice file cannot be found 2> /tmp/fox/fox.md[0m
 [33m[your-program] [0m[0mAlice file cannot be found[0m
 [33m[tester::#VZ4] [0m[92m✓ Received expected response[0m
 [33m[tester::#VZ4] [0m[92m✓ File: /tmp/fox/fox.md is empty[0m

--- a/internal/test_helpers/fixtures/bash/redirection/pass
+++ b/internal/test_helpers/fixtures/bash/redirection/pass
@@ -86,7 +86,7 @@ Debug = true
 [33m[your-program] [0m[0m$ cat /tmp/rat/owl.md[0m
 [33m[your-program] [0m[0mls: nonexistent: No such file or directory[0m
 [33m[tester::#UN3] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo "David says Error" 2>> /tmp/rat/pig.md[0m
+[33m[your-program] [0m[0m$ echo David says Error 2>> /tmp/rat/pig.md[0m
 [33m[your-program] [0m[0mDavid says Error[0m
 [33m[tester::#UN3] [0m[92m✓ Received redirected file content[0m
 [33m[your-program] [0m[0m$ cat nonexistent 2>> /tmp/rat/pig.md[0m

--- a/internal/test_helpers/fixtures/bash/redirection/pass
+++ b/internal/test_helpers/fixtures/bash/redirection/pass
@@ -64,7 +64,7 @@ Debug = true
 [33m[your-program] [0m[0mHello Maria[0m
 [33m[your-program] [0m[0mHello David[0m
 [33m[tester::#EL9] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo "List of files: " > /tmp/rat/fox.md[0m
+[33m[your-program] [0m[0m$ echo List of files: > /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0m$ ls -1 /tmp/fox >> /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/fox.md[0m
 [33m[your-program] [0m[0mList of files:[0m

--- a/internal/test_helpers/fixtures/bash/redirection/pass
+++ b/internal/test_helpers/fixtures/bash/redirection/pass
@@ -12,7 +12,7 @@ Debug = true
 [33m[your-program] [0m[0mpear[0m
 [33m[your-program] [0m[0mpineapple[0m
 [33m[tester::#JV1] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo 'Hello Alice' 1> /tmp/rat/cow.md[0m
+[33m[your-program] [0m[0m$ echo Hello Alice 1> /tmp/rat/cow.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/cow.md[0m
 [33m[your-program] [0m[0mHello Alice[0m
 [33m[tester::#JV1] [0m[92m✓ Received redirected file content[0m
@@ -58,8 +58,8 @@ Debug = true
 [33m[your-program] [0m[0mpineapple[0m
 [33m[your-program] [0m[0mstrawberry[0m
 [33m[tester::#EL9] [0m[92m✓ Received redirected file content[0m
-[33m[your-program] [0m[0m$ echo 'Hello Maria' 1>> /tmp/rat/dog.md[0m
-[33m[your-program] [0m[0m$ echo 'Hello David' 1>> /tmp/rat/dog.md[0m
+[33m[your-program] [0m[0m$ echo Hello Maria 1>> /tmp/rat/dog.md[0m
+[33m[your-program] [0m[0m$ echo Hello David 1>> /tmp/rat/dog.md[0m
 [33m[your-program] [0m[0m$ cat /tmp/rat/dog.md[0m
 [33m[your-program] [0m[0mHello Maria[0m
 [33m[your-program] [0m[0mHello David[0m

--- a/internal/test_helpers/fixtures/bash/redirection/pass
+++ b/internal/test_helpers/fixtures/bash/redirection/pass
@@ -33,7 +33,7 @@ Debug = true
 [33m[your-program] [0m[0m$ cat /tmp/fox/dog.md[0m
 [33m[your-program] [0m[0mls: nonexistent: No such file or directory[0m
 [33m[tester::#VZ4] [0m[92m✓ Received redirected error message[0m
-[33m[your-program] [0m[0m$ echo 'Alice file cannot be found' 2> /tmp/fox/fox.md[0m
+[33m[your-program] [0m[0m$ echo Alice file cannot be found 2> /tmp/fox/fox.md[0m
 [33m[your-program] [0m[0mAlice file cannot be found[0m
 [33m[tester::#VZ4] [0m[92m✓ Received expected response[0m
 [33m[tester::#VZ4] [0m[92m✓ File: /tmp/fox/fox.md is empty[0m


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/rust-jv1-redirect-stdout-seems-to-require-ni6-single-quotes/15850/5

Issue: Redirection depends on Quoting. When the extensions are out of order, it becomes a problem.

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the redirection stage tests/fixtures to stop relying on quoted `echo` arguments, which can alter which participant shells pass or fail. Risk is limited to test expectations but impacts challenge validation.
> 
> **Overview**
> Redirection stage test commands (`r1`–`r4`) were updated to remove single/double quoting around `echo` arguments (including multi-word strings) when used with `>`/`>>` and `2>`/`2>>`, reducing the tests’ dependence on quoting behavior.
> 
> Corresponding golden fixtures for both `bash` and `ash` were updated to match the new command transcripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effcbabbe4b07429590eedc77d59a68e226bb82d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->