### PR TITLE
Parameter Expansion (2/2)

### DIFF
--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -67,7 +67,7 @@ func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -1,7 +1,79 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	// Declare two variables with valid names and random values
+	words := random.RandomWords(4)
+	integerSuffixes := random.RandomInts(1, 10, 2)
+	variableName1 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[0][:1])+words[0][1:],
+		integerSuffixes[0],
+	)
+	variableName2 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[1][:1])+words[1][1:],
+		integerSuffixes[1],
+	)
+	varValue1 := words[2]
+	varValue2 := words[3]
+
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: varValue1}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: varValue2}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Run the executable with $VAR1 $VAR2 — shell must expand before passing args
+	command := fmt.Sprintf("%s $%s $%s", executableName, variableName1, variableName2)
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		fmt.Sprintf("Arg #1: %s", varValue1),
+		fmt.Sprintf("Arg #2: %s", varValue2),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -76,7 +76,7 @@ func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -1,7 +1,88 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	// Declare two variables with valid names and random values
+	words := random.RandomWords(6)
+	integerSuffixes := random.RandomInts(1, 10, 2)
+	variableName1 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[0][:1])+words[0][1:],
+		integerSuffixes[0],
+	)
+	variableName2 := fmt.Sprintf(
+		"%s_%d",
+		strings.ToUpper(words[1][:1])+words[1][1:],
+		integerSuffixes[1],
+	)
+	variableValue1 := words[2]
+	variableValue2 := words[3]
+	literalPrefix := words[4]
+	literalSuffix := words[5]
+
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: variableValue1}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: variableValue2}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	// Run the executable with ${VAR1} embedded between random literal prefix/suffix,
+	// and ${VAR2} as a standalone brace-expansion argument.
+	argument1 := fmt.Sprintf("%s_${%s}_%s", literalPrefix, variableName1, literalSuffix)
+	argument2 := fmt.Sprintf("${%s}", variableName2)
+	command := fmt.Sprintf("%s %s %s", executableName, argument1, argument2)
+
+	expectedArgument1 := fmt.Sprintf("%s_%s_%s", literalPrefix, variableValue1, literalSuffix)
+	expectedArgument2 := variableValue2
+
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		fmt.Sprintf("Arg #1: %s", expectedArgument1),
+		fmt.Sprintf("Arg #2: %s", expectedArgument2),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/codecrafters-io/shell-tester/internal/assertions"
 	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
@@ -55,7 +54,7 @@ func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	testCase := test_cases.CommandWithMultilineResponseTestCase{
-		Command:            strings.Join([]string{command}, " "),
+		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -1,7 +1,67 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/codecrafters-io/shell-tester/internal/assertions"
+	"github.com/codecrafters-io/shell-tester/internal/logged_shell_asserter"
+	"github.com/codecrafters-io/shell-tester/internal/shell_executable"
+	"github.com/codecrafters-io/shell-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
-	return nil
+	logger := stageHarness.Logger
+	shell := shell_executable.NewShellExecutable(stageHarness)
+
+	commandMetadata := getRandomString()
+	executableName := "custom_exe_" + strconv.Itoa(random.RandomInt(1000, 9999))
+
+	_, err := SetUpCustomCommands(stageHarness, shell, []CommandDetails{
+		{CommandType: "signature_printer", CommandName: executableName, CommandMetadata: commandMetadata},
+	}, true)
+	if err != nil {
+		return err
+	}
+	logAvailableExecutables(logger, []string{executableName})
+
+	asserter := logged_shell_asserter.NewLoggedShellAsserter(shell)
+	if err := asserter.StartShellAndAssertPrompt(true); err != nil {
+		return err
+	}
+
+	existingValue := random.RandomWords(1)[0]
+	if err := (test_cases.DeclareAssignmentTestCase{Variable: "existing", Value: existingValue}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	integerSuffixes := random.RandomInts(1, 99, 2)
+	command := fmt.Sprintf(
+		"%s ${missing_var_%d}_suffix ${existing} ${missing_var_%d}",
+		executableName,
+		integerSuffixes[0],
+		integerSuffixes[1],
+	)
+
+	expectedLines := []string{
+		"Program was passed 3 args (including program name).",
+		fmt.Sprintf("Arg #0 (program name): %s", executableName),
+		"Arg #1: _suffix",
+		fmt.Sprintf("Arg #2: %s", existingValue),
+		fmt.Sprintf("Program Signature: %s", commandMetadata),
+	}
+
+	testCase := test_cases.CommandWithMultilineResponseTestCase{
+		Command:            strings.Join([]string{command}, " "),
+		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
+		SuccessMessage:     "✓ Received expected response",
+	}
+	if err := testCase.Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
+	return logAndQuit(asserter, nil)
 }

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -46,10 +46,56 @@ Debug = true
 [33m[tester::#DB8] [0m[92mTest passed.[0m
 
 [33m[tester::#GE9] [0m[94mRunning tests for Stage #GE9 (ge9)[0m
+[33m[tester::#GE9] [setup] [0m[94mexport PATH=/tmp/pig:$PATH[0m
+[33m[tester::#GE9] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#GE9] [setup] [0m[94m- custom_exe_6864[0m
+[33m[tester::#GE9] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare Grape_1=strawberry[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare Pear_2=banana[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_6864 $Grape_1 $Pear_2[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_6864[0m
+[33m[your-program] [0m[0mArg #1: strawberry[0m
+[33m[your-program] [0m[0mArg #2: banana[0m
+[33m[your-program] [0m[0mProgram Signature: 2314588360[0m
+[33m[tester::#GE9] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#GE9] [0m[92mTest passed.[0m
 
 [33m[tester::#BR2] [0m[94mRunning tests for Stage #BR2 (br2)[0m
+[33m[tester::#BR2] [setup] [0m[94mexport PATH=/tmp/owl:$PATH[0m
+[33m[tester::#BR2] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#BR2] [setup] [0m[94m- custom_exe_5355[0m
+[33m[tester::#BR2] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare Raspberry_2=mango[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare Pineapple_9=pear[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_5355 grape_${Raspberry_2}_banana ${Pineapple_9}[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_5355[0m
+[33m[your-program] [0m[0mArg #1: grape_mango_banana[0m
+[33m[your-program] [0m[0mArg #2: pear[0m
+[33m[your-program] [0m[0mProgram Signature: 4420233970[0m
+[33m[tester::#BR2] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#BR2] [0m[92mTest passed.[0m
 
 [33m[tester::#MY0] [0m[94mRunning tests for Stage #MY0 (my0)[0m
+[33m[tester::#MY0] [setup] [0m[94mexport PATH=/tmp/rat:$PATH[0m
+[33m[tester::#MY0] [setup] [0m[94mAvailable executables:[0m
+[33m[tester::#MY0] [setup] [0m[94m- custom_exe_8866[0m
+[33m[tester::#MY0] [0m[94mRunning ./your_shell.sh[0m
+[33m[your-program] [0m[0m$ declare existing=mango[0m
+[33m[tester::#MY0] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ custom_exe_8866 ${missing_var_8}_suffix ${existing} ${missing_var_46}[0m
+[33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
+[33m[your-program] [0m[0mArg #0 (program name): custom_exe_8866[0m
+[33m[your-program] [0m[0mArg #1: _suffix[0m
+[33m[your-program] [0m[0mArg #2: mango[0m
+[33m[your-program] [0m[0mProgram Signature: 7313273050[0m
+[33m[tester::#MY0] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ [0m
 [33m[tester::#MY0] [0m[92mTest passed.[0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to test stages and golden fixtures; primary risk is increased flakiness if randomized names/values ever collide or produce edge-case tokens.
> 
> **Overview**
> Adds concrete implementations for `testPEX5`, `testPEX6`, and `testPEX7`, replacing stubs with end-to-end tests that set variables via `declare` and then verify argument expansion when invoking a generated `signature_printer` executable.
> 
> Stage 5 asserts basic `$VAR` expansion into argv, stage 6 asserts brace form `${VAR}` including embedding within surrounding literals, and stage 7 asserts missing variables expand to an empty string (including inside a larger token). Updates the bash fixture `parameter_expansion/pass` to include the new expected transcripts (PATH setup, executable listing, and multiline argv output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a29ac6989511a53611b778264a73ca1d29d5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->