### PR TITLE
Prevent virtual terminal data race

### DIFF
--- a/internal/vt/virtual_terminal.go
+++ b/internal/vt/virtual_terminal.go
@@ -1,11 +1,14 @@
 package virtual_terminal
 
 import (
+	"sync"
+
 	"github.com/charmbracelet/x/vt"
 	"github.com/codecrafters-io/shell-tester/internal/screen_state"
 )
 
 type VirtualTerminal struct {
+	mu       sync.RWMutex
 	vt       *vt.Terminal
 	rows     int
 	cols     int
@@ -50,10 +53,15 @@ func (vt *VirtualTerminal) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
 	return vt.vt.Write(p)
 }
 
 func (vt *VirtualTerminal) GetScreenState() screen_state.ScreenState {
+	vt.mu.RLock()
+	defer vt.mu.RUnlock()
+
 	cellMatrix := make([][]string, vt.rows)
 
 	for i := 0; i < vt.rows; i++ {


### PR DESCRIPTION
Add mutex to VirtualTerminal to prevent data race during concurrent writes and reads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds simple locking around virtual terminal reads/writes; low risk but could surface as performance contention or deadlocks if future code takes locks inconsistently.
> 
> **Overview**
> Adds a `sync.RWMutex` to `VirtualTerminal` and guards `Write` with an exclusive lock and `GetScreenState` with a read lock to prevent concurrent access races to the underlying `vt.Terminal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e40f126b3709fd2a9d114bcbcd2435daed8a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->