### PR TITLE
Parameter Expansion Updates

### DIFF
--- a/internal/stage_pex2.go
+++ b/internal/stage_pex2.go
@@ -21,7 +21,7 @@ func testPEX2(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	missingVariable := "missing_variable_" + strconv.Itoa(random.RandomInt(1, 100))
 
-	testCase := test_cases.DeclarePrintErrorTestCase{
+	testCase := test_cases.DeclarePrintMissingVariableTestCase{
 		Variable: missingVariable,
 	}
 

--- a/internal/stage_pex3.go
+++ b/internal/stage_pex3.go
@@ -33,8 +33,8 @@ func testPEX3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	missingVariable := "missing_" + random.RandomWords(1)[0]
-	printErrorTestCase := test_cases.DeclarePrintErrorTestCase{Variable: missingVariable}
-	if err := printErrorTestCase.Run(asserter, shell, logger); err != nil {
+	printMissingVariableTestCase := test_cases.DeclarePrintMissingVariableTestCase{Variable: missingVariable}
+	if err := printMissingVariableTestCase.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_pex4.go
+++ b/internal/stage_pex4.go
@@ -19,27 +19,33 @@ func testPEX4(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	words := random.RandomWords(4)
+	words := random.RandomWords(6)
 
-	// Valid assignment: underscore-prefixed name
+	// Valid assignment: name starting with an underscore
 	validVariable := "_" + words[0]
 	validVariableValue := words[1]
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: validVariable, Value: validVariableValue}).Run(asserter, shell, logger); err != nil {
+	underscorePrefixedAssignment := test_cases.DeclareAssignmentTestCase{Variable: validVariable, Value: validVariableValue}
+	if err := underscorePrefixedAssignment.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
 	// Invalid assignment: name starting with a digit
-	invalidVariable := fmt.Sprintf("%d%s", random.RandomInt(2, 9), words[2])
+	invalidDigitPrefixedVariable := fmt.Sprintf("%d%s", random.RandomInt(2, 9), words[2])
 	invalidVariableValue := words[3]
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: invalidVariable, Value: invalidVariableValue}).Run(asserter, shell, logger); err != nil {
+	digitPrefixedAssignment := test_cases.DeclareAssignmentTestCase{Variable: invalidDigitPrefixedVariable, Value: invalidVariableValue}
+	if err := digitPrefixedAssignment.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	if err := (test_cases.DeclarePrintTestCase{Variable: validVariable, Value: validVariableValue}).Run(asserter, shell, logger); err != nil {
+	// Invalid assignment: name with a hyphen in the middle
+	hyphenInMiddleVariable := words[4] + "-" + words[5]
+	hyphenInMiddleAssignment := test_cases.DeclareAssignmentTestCase{Variable: hyphenInMiddleVariable, Value: validVariableValue}
+	if err := hyphenInMiddleAssignment.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	if err := (test_cases.DeclarePrintErrorTestCase{Variable: invalidVariable}).Run(asserter, shell, logger); err != nil {
+	printValidVariable := test_cases.DeclarePrintTestCase{Variable: validVariable, Value: validVariableValue}
+	if err := printValidVariable.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_pex5.go
+++ b/internal/stage_pex5.go
@@ -34,8 +34,8 @@ func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Declare two variables with valid names and random values
-	words := random.RandomWords(4)
-	integerSuffixes := random.RandomInts(1, 10, 2)
+	words := random.RandomWords(5)
+	integerSuffixes := random.RandomInts(0, 10, 2)
 	variableName1 := fmt.Sprintf(
 		"%s_%d",
 		strings.ToUpper(words[0][:1])+words[0][1:],
@@ -46,32 +46,38 @@ func testPEX5(stageHarness *test_case_harness.TestCaseHarness) error {
 		strings.ToUpper(words[1][:1])+words[1][1:],
 		integerSuffixes[1],
 	)
-	varValue1 := words[2]
-	varValue2 := words[3]
+	variableValue1 := words[2]
+	variableValue2 := words[3]
+	literalPrefix := words[4]
 
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: varValue1}).Run(asserter, shell, logger); err != nil {
+	assignVariable1 := test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: variableValue1}
+	if err := assignVariable1.Run(asserter, shell, logger); err != nil {
 		return err
 	}
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: varValue2}).Run(asserter, shell, logger); err != nil {
+
+	assignVariable2 := test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: variableValue2}
+	if err := assignVariable2.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	// Run the executable with $VAR1 $VAR2 — shell must expand before passing args
-	command := fmt.Sprintf("%s $%s $%s", executableName, variableName1, variableName2)
+	// Run the executable with:
+	//   $VAR1             — standalone expansion
+	//   literalPrefix_$VAR2 — expansion embedded mid-word (no braces)
+	command := fmt.Sprintf("%s $%s %s_$%s", executableName, variableName1, literalPrefix, variableName2)
 	expectedLines := []string{
 		"Program was passed 3 args (including program name).",
 		fmt.Sprintf("Arg #0 (program name): %s", executableName),
-		fmt.Sprintf("Arg #1: %s", varValue1),
-		fmt.Sprintf("Arg #2: %s", varValue2),
+		fmt.Sprintf("Arg #1: %s", variableValue1),
+		fmt.Sprintf("Arg #2: %s_%s", literalPrefix, variableValue2),
 		fmt.Sprintf("Program Signature: %s", commandMetadata),
 	}
 
-	testCase := test_cases.CommandWithMultilineResponseTestCase{
+	bareExpansionCall := test_cases.CommandWithMultilineResponseTestCase{
 		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}
-	if err := testCase.Run(asserter, shell, logger); err != nil {
+	if err := bareExpansionCall.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_pex6.go
+++ b/internal/stage_pex6.go
@@ -33,8 +33,7 @@ func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	// Declare two variables with valid names and random values
-	words := random.RandomWords(6)
+	words := random.RandomWords(7)
 	integerSuffixes := random.RandomInts(1, 10, 2)
 	variableName1 := fmt.Sprintf(
 		"%s_%d",
@@ -50,22 +49,26 @@ func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
 	variableValue2 := words[3]
 	literalPrefix := words[4]
 	literalSuffix := words[5]
+	literalSuffix2 := words[6]
 
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: variableValue1}).Run(asserter, shell, logger); err != nil {
+	assignVar1 := test_cases.DeclareAssignmentTestCase{Variable: variableName1, Value: variableValue1}
+	if err := assignVar1.Run(asserter, shell, logger); err != nil {
 		return err
 	}
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: variableValue2}).Run(asserter, shell, logger); err != nil {
+	assignVar2 := test_cases.DeclareAssignmentTestCase{Variable: variableName2, Value: variableValue2}
+	if err := assignVar2.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	// Run the executable with ${VAR1} embedded between random literal prefix/suffix,
-	// and ${VAR2} as a standalone brace-expansion argument.
+	// Run the executable with:
+	//   prefix_${VAR1}_suffix  — braces in the middle of a word
+	//   ${VAR2}_literal        — braces at the start of a word
 	argument1 := fmt.Sprintf("%s_${%s}_%s", literalPrefix, variableName1, literalSuffix)
-	argument2 := fmt.Sprintf("${%s}", variableName2)
+	argument2 := fmt.Sprintf("${%s}_%s", variableName2, literalSuffix2)
 	command := fmt.Sprintf("%s %s %s", executableName, argument1, argument2)
 
 	expectedArgument1 := fmt.Sprintf("%s_%s_%s", literalPrefix, variableValue1, literalSuffix)
-	expectedArgument2 := variableValue2
+	expectedArgument2 := fmt.Sprintf("%s_%s", variableValue2, literalSuffix2)
 
 	expectedLines := []string{
 		"Program was passed 3 args (including program name).",
@@ -75,12 +78,12 @@ func testPEX6(stageHarness *test_case_harness.TestCaseHarness) error {
 		fmt.Sprintf("Program Signature: %s", commandMetadata),
 	}
 
-	testCase := test_cases.CommandWithMultilineResponseTestCase{
+	bracedExpansionCall := test_cases.CommandWithMultilineResponseTestCase{
 		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}
-	if err := testCase.Run(asserter, shell, logger); err != nil {
+	if err := bracedExpansionCall.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/stage_pex7.go
+++ b/internal/stage_pex7.go
@@ -32,33 +32,41 @@ func testPEX7(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	existingValue := random.RandomWords(1)[0]
-	if err := (test_cases.DeclareAssignmentTestCase{Variable: "existing", Value: existingValue}).Run(asserter, shell, logger); err != nil {
+	words := random.RandomWords(2)
+	variableName := words[0]
+	variableValue := words[1]
+
+	assignVariable := test_cases.DeclareAssignmentTestCase{Variable: variableName, Value: variableValue}
+	if err := assignVariable.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
-	integerSuffixes := random.RandomInts(1, 99, 2)
+	integerSuffixes := random.RandomInts(0, 10, 3)
+
 	command := fmt.Sprintf(
-		"%s ${missing_var_%d}_suffix ${existing} ${missing_var_%d}",
+		"%s ${missing_var_%d}_suffix ${%s} ${missing_var_%d} $missing_var_%d",
 		executableName,
 		integerSuffixes[0],
+		variableName,
 		integerSuffixes[1],
+		integerSuffixes[2],
 	)
 
 	expectedLines := []string{
 		"Program was passed 3 args (including program name).",
 		fmt.Sprintf("Arg #0 (program name): %s", executableName),
 		"Arg #1: _suffix",
-		fmt.Sprintf("Arg #2: %s", existingValue),
+		fmt.Sprintf("Arg #2: %s", variableValue),
 		fmt.Sprintf("Program Signature: %s", commandMetadata),
 	}
 
-	testCase := test_cases.CommandWithMultilineResponseTestCase{
+	missingVarExpansionCall := test_cases.CommandWithMultilineResponseTestCase{
 		Command:            command,
 		MultiLineAssertion: assertions.NewMultiLineAssertion(expectedLines),
 		SuccessMessage:     "✓ Received expected response",
 	}
-	if err := testCase.Run(asserter, shell, logger); err != nil {
+
+	if err := missingVarExpansionCall.Run(asserter, shell, logger); err != nil {
 		return err
 	}
 

--- a/internal/test_cases/declare_assignment_test_case.go
+++ b/internal/test_cases/declare_assignment_test_case.go
@@ -33,14 +33,18 @@ func (t DeclareAssignmentTestCase) Run(asserter *logged_shell_asserter.LoggedShe
 	}
 
 	expectedOutput := fmt.Sprintf("declare: `%s': not a valid identifier", assignment)
+
 	testCase := CommandResponseTestCase{
 		Command:        fmt.Sprintf("declare %s", assignment),
 		ExpectedOutput: expectedOutput,
 		FallbackPatterns: []*regexp.Regexp{
 			// bash prefixes with "bash: "
 			regexp.MustCompile(fmt.Sprintf("^bash: declare: `%s': not a valid identifier$", regexp.QuoteMeta(assignment))),
-			// zsh uses "not an identifier" phrasing
+			// zsh uses "not an identifier" for names starting with a digit
 			regexp.MustCompile(fmt.Sprintf(`^declare: not an identifier: %s$`, regexp.QuoteMeta(t.Variable))),
+			// zsh uses "not valid in this context"
+			// for names with valid starting character but invalid characters in the middle
+			regexp.MustCompile(fmt.Sprintf(`^declare: not valid in this context: %s$`, regexp.QuoteMeta(t.Variable))),
 		},
 		SuccessMessage: "✓ Received expected response",
 	}

--- a/internal/test_cases/declare_assignment_test_case.go
+++ b/internal/test_cases/declare_assignment_test_case.go
@@ -43,7 +43,7 @@ func (t DeclareAssignmentTestCase) Run(asserter *logged_shell_asserter.LoggedShe
 			// zsh uses "not an identifier" for names starting with a digit
 			regexp.MustCompile(fmt.Sprintf(`^declare: not an identifier: %s$`, regexp.QuoteMeta(t.Variable))),
 			// zsh uses "not valid in this context"
-			// for names with valid starting character but invalid characters in the middle
+			// for names with valid starting character but with invalid characters in the middle
 			regexp.MustCompile(fmt.Sprintf(`^declare: not valid in this context: %s$`, regexp.QuoteMeta(t.Variable))),
 		},
 		SuccessMessage: "✓ Received expected response",

--- a/internal/test_cases/declare_print_missing_variable_test_case.go
+++ b/internal/test_cases/declare_print_missing_variable_test_case.go
@@ -9,21 +9,20 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-// DeclarePrintErrorTestCase tests `declare -p VAR` when the variable does not exist.
+// DeclarePrintMissingVariableTestCase tests `declare -p VAR` when the variable does not exist.
 // Expected output: declare: VAR: not found
-type DeclarePrintErrorTestCase struct {
+type DeclarePrintMissingVariableTestCase struct {
 	Variable string
 }
 
-func (t DeclarePrintErrorTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
+func (t DeclarePrintMissingVariableTestCase) Run(asserter *logged_shell_asserter.LoggedShellAsserter, shell *shell_executable.ShellExecutable, logger *logger.Logger) error {
 	fallbackPatterns := []*regexp.Regexp{
 		regexp.MustCompile(fmt.Sprintf(`^bash: declare: %s: not found$`, regexp.QuoteMeta(t.Variable))),
 		regexp.MustCompile(fmt.Sprintf(`^declare: no such variable: %s$`, regexp.QuoteMeta(t.Variable))),
 	}
 
 	if !isValidIdentifier(t.Variable) {
-		// zsh rejects invalid identifiers passed to -p
-		fallbackPatterns = append(fallbackPatterns, regexp.MustCompile(fmt.Sprintf(`^declare: bad argument to -p: %s$`, regexp.QuoteMeta(t.Variable))))
+		panic(fmt.Sprintf("Codecrafters Internal Error - DeclarePrintErrorTestCase called on invalid identifier %s", t.Variable))
 	}
 
 	testCase := CommandResponseTestCase{

--- a/internal/test_cases/declare_print_missing_variable_test_case.go
+++ b/internal/test_cases/declare_print_missing_variable_test_case.go
@@ -22,7 +22,7 @@ func (t DeclarePrintMissingVariableTestCase) Run(asserter *logged_shell_asserter
 	}
 
 	if !isValidIdentifier(t.Variable) {
-		panic(fmt.Sprintf("Codecrafters Internal Error - DeclarePrintErrorTestCase called on invalid identifier %s", t.Variable))
+		panic(fmt.Sprintf("Codecrafters Internal Error - DeclarePrintMissingVariableTestCase called on invalid identifier %s", t.Variable))
 	}
 
 	testCase := CommandResponseTestCase{

--- a/internal/test_helpers/fixtures/bash/parameter_expansion/pass
+++ b/internal/test_helpers/fixtures/bash/parameter_expansion/pass
@@ -41,11 +41,11 @@ Debug = true
 [33m[your-program] [0m[0m$ declare 5raspberry=apple[0m
 [33m[your-program] [0m[0mbash: declare: `5raspberry=apple': not a valid identifier[0m
 [33m[tester::#DB8] [0m[92m✓ Received expected response[0m
+[33m[your-program] [0m[0m$ declare pear-grape=orange[0m
+[33m[your-program] [0m[0mbash: declare: `pear-grape=orange': not a valid identifier[0m
+[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ declare -p _pineapple[0m
 [33m[your-program] [0m[0mdeclare -- _pineapple="orange"[0m
-[33m[tester::#DB8] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m[0m$ declare -p 5raspberry[0m
-[33m[your-program] [0m[0mbash: declare: 5raspberry: not found[0m
 [33m[tester::#DB8] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ [0m
 [33m[tester::#DB8] [0m[92mTest passed.[0m
@@ -55,15 +55,15 @@ Debug = true
 [33m[tester::#GE9] [setup] [0m[94mAvailable executables:[0m
 [33m[tester::#GE9] [setup] [0m[94m- custom_exe_6864[0m
 [33m[tester::#GE9] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ declare Grape_1=strawberry[0m
+[33m[your-program] [0m[0m$ declare Grape_2=strawberry[0m
 [33m[tester::#GE9] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m[0m$ declare Pear_2=banana[0m
+[33m[your-program] [0m[0m$ declare Pear_3=banana[0m
 [33m[tester::#GE9] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m[0m$ custom_exe_6864 $Grape_1 $Pear_2[0m
+[33m[your-program] [0m[0m$ custom_exe_6864 $Grape_2 raspberry_$Pear_3[0m
 [33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
 [33m[your-program] [0m[0mArg #0 (program name): custom_exe_6864[0m
 [33m[your-program] [0m[0mArg #1: strawberry[0m
-[33m[your-program] [0m[0mArg #2: banana[0m
+[33m[your-program] [0m[0mArg #2: raspberry_banana[0m
 [33m[your-program] [0m[0mProgram Signature: 2314588360[0m
 [33m[tester::#GE9] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ [0m
@@ -78,11 +78,11 @@ Debug = true
 [33m[tester::#BR2] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ declare Pineapple_9=pear[0m
 [33m[tester::#BR2] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m[0m$ custom_exe_5355 grape_${Raspberry_2}_banana ${Pineapple_9}[0m
+[33m[your-program] [0m[0m$ custom_exe_5355 grape_${Raspberry_2}_banana ${Pineapple_9}_orange[0m
 [33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
 [33m[your-program] [0m[0mArg #0 (program name): custom_exe_5355[0m
 [33m[your-program] [0m[0mArg #1: grape_mango_banana[0m
-[33m[your-program] [0m[0mArg #2: pear[0m
+[33m[your-program] [0m[0mArg #2: pear_orange[0m
 [33m[your-program] [0m[0mProgram Signature: 4420233970[0m
 [33m[tester::#BR2] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ [0m
@@ -93,13 +93,13 @@ Debug = true
 [33m[tester::#MY0] [setup] [0m[94mAvailable executables:[0m
 [33m[tester::#MY0] [setup] [0m[94m- custom_exe_8866[0m
 [33m[tester::#MY0] [0m[94mRunning ./your_shell.sh[0m
-[33m[your-program] [0m[0m$ declare existing=mango[0m
+[33m[your-program] [0m[0m$ declare mango=orange[0m
 [33m[tester::#MY0] [0m[92m✓ Received expected response[0m
-[33m[your-program] [0m[0m$ custom_exe_8866 ${missing_var_8}_suffix ${existing} ${missing_var_46}[0m
+[33m[your-program] [0m[0m$ custom_exe_8866 ${missing_var_9}_suffix ${mango} ${missing_var_7} $missing_var_6[0m
 [33m[your-program] [0m[0mProgram was passed 3 args (including program name).[0m
 [33m[your-program] [0m[0mArg #0 (program name): custom_exe_8866[0m
 [33m[your-program] [0m[0mArg #1: _suffix[0m
-[33m[your-program] [0m[0mArg #2: mango[0m
+[33m[your-program] [0m[0mArg #2: orange[0m
 [33m[your-program] [0m[0mProgram Signature: 7313273050[0m
 [33m[tester::#MY0] [0m[92m✓ Received expected response[0m
 [33m[your-program] [0m[0m$ [0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates multiple parameter-expansion stages and assertions, which can change pass/fail outcomes across different shells and user implementations. Risk is moderate because it alters the tester’s canonical expectations for identifier validity and expansion behavior.
> 
> **Overview**
> **Parameter expansion stage tests are updated to be stricter and more representative.** Missing-variable printing via `declare -p` is renamed/clarified as `DeclarePrintMissingVariableTestCase` and now hard-fails if invoked with an invalid identifier.
> 
> **Identifier validation coverage is expanded.** Stage `pex4` adds an additional invalid assignment case (hyphens in variable names) and `DeclareAssignmentTestCase` broadens zsh-compatible fallback patterns to distinguish digit-prefixed vs mid-string invalid characters.
> 
> **Argument expansion scenarios are strengthened.** Stages `pex5`–`pex7` now assert expansions embedded within words (both bare `$VAR` and braced `${VAR}` forms), braced expansions at word boundaries with literal suffixes, and mixed missing-variable expansions, with fixture expectations updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b56563547b2d5e80a806d0127cba05ccff31ea4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->