### PR TITLE
Fix Java OOM by registering kill as TeardownFunc

### DIFF
--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -68,8 +68,7 @@ func NewShellExecutable(stageHarness *test_case_harness.TestCaseHarness) *ShellE
 
 	b.env = environ.New(os.Environ())
 
-	// TODO: Kill pty process?
-	// stageHarness.RegisterTeardownFunc(func() { b.Kill() })
+	stageHarness.RegisterTeardownFunc(func() { b.Kill() })
 
 	return b
 }
@@ -95,6 +94,13 @@ func (b *ShellExecutable) GetPid() int {
 		panic("Codecrafters Internal Error: ShellExecutable.GetPid called without starting shell")
 	}
 	return b.cmd.Process.Pid
+}
+
+func (b *ShellExecutable) Kill() {
+	if b.cmd == nil || b.cmd.Process == nil {
+		panic("Codecrafters Internal Error: ShellExecutable.Kill called without starting shell")
+	}
+	b.cmd.Process.Kill()
 }
 
 func (b *ShellExecutable) Start(args ...string) error {

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -100,7 +100,15 @@ func (b *ShellExecutable) Kill() {
 	if b.cmd == nil || b.cmd.Process == nil {
 		return
 	}
-	b.cmd.Process.Kill()
+	if b.memoryMonitor != nil {
+		b.memoryMonitor.stop()
+		b.memoryMonitor = nil
+	}
+	pid := b.cmd.Process.Pid
+	// Kill the process group so child processes do not outlive teardown (creack/pty sets Setsid=true).
+	// Same approach as memory_limit_linux.go when OOM killing.
+	syscall.Kill(-pid, syscall.SIGKILL)
+	syscall.Kill(pid, syscall.SIGKILL)
 }
 
 func (b *ShellExecutable) Start(args ...string) error {

--- a/internal/shell_executable/shell_executable.go
+++ b/internal/shell_executable/shell_executable.go
@@ -98,7 +98,7 @@ func (b *ShellExecutable) GetPid() int {
 
 func (b *ShellExecutable) Kill() {
 	if b.cmd == nil || b.cmd.Process == nil {
-		panic("Codecrafters Internal Error: ShellExecutable.Kill called without starting shell")
+		return
 	}
 	b.cmd.Process.Kill()
 }

--- a/internal/shell_executable/shell_executable_test.go
+++ b/internal/shell_executable/shell_executable_test.go
@@ -50,21 +50,3 @@ func newMemoryHogExecutable() *ShellExecutable {
 	shell.env = environ.New(os.Environ())
 	return shell
 }
-
-func TestKillNoOpWithoutStart(t *testing.T) {
-	shell := newMemoryHogExecutable()
-	assert.NotPanics(t, func() { shell.Kill() })
-}
-
-func TestKillNoOpWhenStartFails(t *testing.T) {
-	shell := &ShellExecutable{
-		executable:         executable.NewExecutable("/nonexistent/path/to/shell"),
-		stageLogger:        logger.GetQuietLogger(""),
-		programLogger:      logger.GetLogger(false, "[your-program] "),
-		MemoryLimitInBytes: defaultMemoryLimitBytes,
-	}
-	shell.env = environ.New(os.Environ())
-	err := shell.Start()
-	assert.Error(t, err)
-	assert.NotPanics(t, func() { shell.Kill() })
-}

--- a/internal/shell_executable/shell_executable_test.go
+++ b/internal/shell_executable/shell_executable_test.go
@@ -50,3 +50,21 @@ func newMemoryHogExecutable() *ShellExecutable {
 	shell.env = environ.New(os.Environ())
 	return shell
 }
+
+func TestKillNoOpWithoutStart(t *testing.T) {
+	shell := newMemoryHogExecutable()
+	assert.NotPanics(t, func() { shell.Kill() })
+}
+
+func TestKillNoOpWhenStartFails(t *testing.T) {
+	shell := &ShellExecutable{
+		executable:         executable.NewExecutable("/nonexistent/path/to/shell"),
+		stageLogger:        logger.GetQuietLogger(""),
+		programLogger:      logger.GetLogger(false, "[your-program] "),
+		MemoryLimitInBytes: defaultMemoryLimitBytes,
+	}
+	shell.env = environ.New(os.Environ())
+	err := shell.Start()
+	assert.Error(t, err)
+	assert.NotPanics(t, func() { shell.Kill() })
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and SIGKILL teardown for all shell-based tests; behavior is intentional but affects every stage using ShellExecutable on Linux.
> 
> **Overview**
> **Shell test harnesses now tear down PTY child processes reliably** by wiring cleanup that was previously left as a TODO.
> 
> `NewShellExecutable` registers **`Kill()`** on stage teardown so the spawned program (and its children) are stopped when a test stage finishes. **`Kill()`** is a no-op if nothing was started; otherwise it stops the memory monitor, then sends **`SIGKILL`** to the process group and the leader PID—matching the existing OOM kill path for **`creack/pty`** session leaders so JVMs and other subprocesses do not keep running and skew memory limits (e.g. Java OOM scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d028ccacc5987a86af664b98630d86db9d56a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->