### PR TITLE
Enhance testBg9Recycle function

### DIFF
--- a/internal/stage_bg9.go
+++ b/internal/stage_bg9.go
@@ -153,6 +153,15 @@ func testBg9Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	sleepCommand2 := "sleep 50"
+	if err := (&test_cases.BackgroundCommandResponseTestCase{
+		Command:           sleepCommand2,
+		ExpectedJobNumber: 3,
+		SuccessMessage:    "✓ Output includes job number with PID",
+	}).Run(asserter, shell, logger); err != nil {
+		return err
+	}
+
 	if err := WriteToFile(stageHarness, fifoPath, ""); err != nil {
 		return err
 	}
@@ -163,7 +172,7 @@ func testBg9Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		Command:               fmt.Sprintf("echo %s", echoArgument),
 		ExpectedCommandOutput: echoArgument,
 		ExpectedReapedJobEntries: []*test_cases.BackgroundJobStatusEntry{{
-			JobNumber: 2, Status: "Done", LaunchCommand: bgCatCommand, Marker: test_cases.CurrentJob,
+			JobNumber: 2, Status: "Done", LaunchCommand: bgCatCommand, Marker: test_cases.PreviousJob,
 		}},
 		SuccessMessage: "✓ Received output for echo followed by an entry for the reaped job",
 	}
@@ -171,21 +180,22 @@ func testBg9Recycle(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	sleepCommand2 := "sleep 50"
+	sleepCommand3 := "sleep 10"
 	if err := (&test_cases.BackgroundCommandResponseTestCase{
-		Command:           sleepCommand2,
+		Command:           sleepCommand3,
 		ExpectedJobNumber: 2,
-		SuccessMessage:    "✓ Output includes job number with PID",
+		SuccessMessage:    "✓ Output includes recycled job number with PID",
 	}).Run(asserter, shell, logger); err != nil {
 		return err
 	}
 
 	jobsTestCase := test_cases.JobsBuiltinResponseTestCase{
 		ExpectedOutputEntries: []test_cases.BackgroundJobStatusEntry{
-			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.PreviousJob},
-			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.CurrentJob},
+			{JobNumber: 1, Status: "Running", LaunchCommand: sleepCommand, Marker: test_cases.UnmarkedJob},
+			{JobNumber: 2, Status: "Running", LaunchCommand: sleepCommand3, Marker: test_cases.CurrentJob},
+			{JobNumber: 3, Status: "Running", LaunchCommand: sleepCommand2, Marker: test_cases.PreviousJob},
 		},
-		SuccessMessage: "✓ 2 entries match the running jobs",
+		SuccessMessage: "✓ 3 entries match the running jobs",
 	}
 
 	if err := jobsTestCase.Run(asserter, shell, logger); err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to integration test expectations in `stage_bg9.go`; no production shell behavior is modified.
> 
> **Overview**
> **`testBg9Recycle`** now models job-number recycling with **three** background jobs still running when job 2 finishes, instead of only two.
> 
> A **`sleep 50`** background job is started as **job 3** before the FIFO is closed so job 2 can be reaped. Expectations for the reaped **`cat`** job use **`PreviousJob`** (`-`) rather than **`CurrentJob`**, and the follow-up background launch uses **`sleep 10`** assigned to **recycled job 2**, with an updated success message.
> 
> The final **`jobs`** assertion expects **three** running entries (jobs 1, 2, 3) with markers **unmarked**, **current** (`+`), and **previous** (`-`) respectively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fddf4cf6b6f7c5293b02040a5d7c8264b8e248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->